### PR TITLE
1.3.0 cleanup, other massive changes

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022 # windows-latest
     
     strategy:
       matrix:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -19,7 +19,7 @@ jobs:
     
     strategy:
       matrix:
-        build_config: ["Release", "Debug"]
+        build_config: ["Release"] # "Debug"
 
     steps:
     - uses: actions/checkout@v6
@@ -28,11 +28,11 @@ jobs:
 
     - uses: microsoft/setup-msbuild@v3
     
-    - uses: actions/cache@v5
-      with:
-        path: |
-          ./Dependencies/APCpp
-        key: ${{ runner.os }}-APCpp-${{ matrix.build_config }}-${{ hashFiles('**/APCpp/CMakeLists.txt', '**/APCpp/*.c', '**/APCpp/*.h') }}
+    #- uses: actions/cache@v5
+    #  with:
+    #    path: |
+    #      ./Dependencies/APCpp
+    #    key: ${{ runner.os }}-APCpp-${{ matrix.build_config }}-${{ hashFiles('**/APCpp/CMakeLists.txt', '**/APCpp/*.c', '**/APCpp/*.h') }}
 
     - name: Configure APCpp
       working-directory: ./Dependencies/APCpp

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -289,9 +289,12 @@ namespace APClient
     {
         if (pvID == victoryID / 10)
         {
+            APLogger::print("Client: Sending goal completion from ID %i\n", pvID);
             AP_StoryComplete();
         }
         else {
+            APLogger::print("Client: Sending locations for ID %i\n", pvID);
+
             // Song locations are in pairs
             int64_t APID = pvID * 10;
 

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -287,6 +287,13 @@ namespace APClient
 
     void LocationSend(int64_t pvID)
     {
+        // There is no current way to send an arbitrary ID so limit to received ones. Usually what's on the Tracker.
+        // Specifically to prevent misfires of the AP and Tutorial songs but may benefit Freeplay.
+        if (std::find(recvIDs.begin(), recvIDs.end(), pvID) == recvIDs.end() /*&& !devMode*/) {
+            APLogger::print("Client: Skip location send for ID %i (not received)", pvID);
+            return;
+        }
+
         if (pvID == victoryID / 10)
         {
             APLogger::print("Client: Sending goal completion from ID %i\n", pvID);

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -290,7 +290,7 @@ namespace APClient
         // There is no current way to send an arbitrary ID so limit to received ones. Usually what's on the Tracker.
         // Specifically to prevent misfires of the AP and Tutorial songs but may benefit Freeplay.
         if (std::find(recvIDs.begin(), recvIDs.end(), pvID) == recvIDs.end() /*&& !devMode*/) {
-            APLogger::print("Client: Skip location send for ID %i (not received)", pvID);
+            APLogger::print("Client: Skip location send for ID %i (not received)\n", pvID);
             return;
         }
 

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -23,15 +23,12 @@ namespace APClient
     std::string APLog = ""; // Various memory management concerns.
     bool APLogCopyMode = false;
 
-    // TODO: ID remaps
-    AP_RoomInfo RoomInfo;
-
-    std::string DatapackageChecksum;
-    bool datapackageLoaded = false;
-
-    std::filesystem::path LocalPath = std::filesystem::current_path();
+    // Hold server data messaging
+    std::vector<std::pair<AP_GetServerDataRequest, std::function<void(std::string raw)>>> DataRequests;
 
     // Datapackage
+    std::string DatapackageChecksum;
+    bool datapackageLoaded = false;
 
     nlohmann::json_abi_v3_12_0::json datapackageJSON;
     std::unordered_map<std::string, int64_t> item_name_to_ap_id;
@@ -39,23 +36,21 @@ namespace APClient
     std::unordered_map<std::string, int64_t> location_name_to_id;
     std::unordered_map<int64_t, std::string> location_id_to_name;
 
-    // Item and location tracking
-
-    std::string DataRequestRaw; // Raw should always be a (JSON) string.
-    AP_GetServerDataRequest request;
-    bool requested = false; // state tracking of request since it doesn't provide a null state
-
-    nlohmann::json_abi_v3_12_0::json slotData;
-    std::vector<int64_t> seedIDs = {}; // Song IDs that are part of the seed
-    std::vector<int64_t> recvIDs = {}; // Song IDs received as items
-    std::vector<int64_t> missingIDs = {}; // Song IDs not yet received
-    std::vector<int64_t> CheckedLocations = {}; // Love is War [1] = 10, 11.
-
     // TODO: Relocate?
     int clearGrade = 2;
     char diffs[5][10] = {"Cheap", "Standard", "Great", "Excellent", "Perfect"};
 
-    int64_t victoryID = 0; // The AP Item/Loc ID. (confusion ensues)
+    // Archipelago state
+
+    AP_RoomInfo RoomInfo;
+
+    nlohmann::json_abi_v3_12_0::json slotData;
+    std::vector<int64_t> seedIDs = {}; // Song IDs (Love is War [1] = 1) that are part of the seed
+    std::vector<int64_t> recvIDs = {}; // Song IDs (Love is War [1] = 1) received as items
+    std::vector<int64_t> missingIDs = {}; // Song IDs (Love is War [1] = 1) not yet received
+    std::vector<int64_t> CheckedLocations = {}; // Love is War [1] = 10, 11
+
+    int64_t victoryID = 0; // Song ID * 10, Love is War [1] = 10
     int leekHave = 0;
     int leekNeed = 0;
 
@@ -106,6 +101,80 @@ namespace APClient
         return slotName;
     }
 
+    void SlotData_LeekHave(int leekWinCount)
+    {
+        leekNeed = leekWinCount;
+    }
+
+    void SlotData_ProgHP(int progHP)
+    {
+        progHPTotal = 1 + progHP;
+    }
+
+    void SlotData_Grade(int grade)
+    {
+        clearGrade = grade;
+    }
+
+    void SlotData_VictoryID(int id)
+    {
+        victoryID = id;
+    }
+
+    void SlotData_FinalSongs(std::string raw)
+    {
+        auto final = nlohmann::json::parse(raw);
+        if (final.is_array())
+        {
+            seedIDs = final.get<std::vector<int64_t>>();
+            std::sort(seedIDs.begin(), seedIDs.end());
+        }
+
+        APReload::run();
+        APTraps::reset();
+        UpdateMissing();
+    }
+
+    void ItemClear()
+    {
+        APLogger::print("Client: reset\n");
+        reset();
+    }
+
+    void ItemRecv(int64_t itemID, bool notify)
+    {
+        switch (itemID) {
+        case 1:
+            leekHave += 1;
+            UpdateMissing();
+            break;
+        case 2:
+            break; // Filler
+        case 3:
+            APDeathLink::recvHP();
+            break;
+        case 4:
+            APTraps::touchHidden();
+            break;
+        case 5:
+            APTraps::touchSudden();
+            break;
+        case 9:
+            APTraps::touchIcon();
+            break;
+        default:
+            if (itemID >= 10) {
+                PushRecvID(itemID / 10);
+                APHints::updateByItemName(item_ap_id_to_name[itemID]);
+            }
+        }
+    }
+
+    void LocationChecked(int64_t locationID)
+    {
+        CheckedLocations.push_back(locationID);
+    }
+
     void connect()
     {
         AP_Shutdown();
@@ -122,6 +191,12 @@ namespace APClient
             AP_SetItemRecvCallback(ItemRecv);
             AP_SetLocationCheckedCallback(LocationChecked);
 
+            AP_RegisterSlotDataIntCallback("victoryID", SlotData_VictoryID);
+            AP_RegisterSlotDataIntCallback("scoreGradeNeeded", SlotData_VictoryID);
+            AP_RegisterSlotDataIntCallback("leekWinCount", SlotData_LeekHave);
+            AP_RegisterSlotDataIntCallback("progHP", SlotData_ProgHP);
+            AP_RegisterSlotDataRawCallback("finalSongIDs", SlotData_FinalSongs);
+
             AP_Start();
         }
     }
@@ -130,10 +205,9 @@ namespace APClient
     {
         datapackageLoaded = false;
 
-        slotData = nullptr;
-        requested = false;
-        request.status = AP_RequestStatus::Pending;
-        DataRequestRaw.clear();
+        DataRequests.clear();
+
+        slotData.clear();
 
         seedIDs.clear();
         recvIDs.clear();
@@ -141,7 +215,7 @@ namespace APClient
         CheckedLocations.clear();
 
         say[0] = '\0';
-        APLog = "";
+        APLog.clear();
 
         clearGrade = 2;
         victoryID = 0;
@@ -155,106 +229,6 @@ namespace APClient
 
         APIDHandler::reset();
         APHints::reset();
-    }
-
-    // Server messages
-
-    AP_RequestStatus ServerDataRequest_Raw(std::string key, AP_GetServerDataRequest& rawRequest, bool& rawRequested, std::string& output)
-    {
-        if (!rawRequested)
-        {
-            rawRequested = true;
-
-            APLogger::print("ServerDataRequest_Raw: %s\n", key.c_str());
-            rawRequest.key = key;
-            rawRequest.value = &output;
-            rawRequest.type = AP_DataType::Raw;
-            rawRequest.status = AP_RequestStatus::Pending;
-
-            AP_GetServerData(&rawRequest);
-        }
-
-        if (rawRequested && rawRequest.status == AP_RequestStatus::Done || rawRequest.status == AP_RequestStatus::Error)
-            rawRequested = false;
-
-        return rawRequest.status;
-    }
-
-    void GetSlotData()
-    {
-        if (slotData.is_null() && request.status == AP_RequestStatus::Pending)
-        {
-            APLogger::print(__FUNCTION__" pending\n");
-            auto name = "_read_slot_data_" + std::to_string(AP_GetPlayerID());
-            ServerDataRequest_Raw(name, request, requested, DataRequestRaw);
-            return;
-        }
-
-        if (!slotData.is_null() || !&DataRequestRaw)
-            return;
-
-        // TODO: try catch?
-
-        slotData = nlohmann::json::parse(DataRequestRaw);
-
-        auto final = slotData["finalSongIDs"];
-        if (final.is_array())
-        {
-            seedIDs = final.get<std::vector<int64_t>>();
-            std::sort(seedIDs.begin(), seedIDs.end());
-        }
-
-        // APCpp provides easy int callbacks, but we're already here...
-
-        victoryID = slotData.value("victoryID", 0);
-        clearGrade = slotData.value("scoreGradeNeeded", 2);
-        leekNeed = slotData.value("leekWinCount", 1);
-        progHPTotal = 1 + slotData.value("progHP", 0); // The value is how many are in the pool, so +1.
-
-        // TODO: Remaps
-
-        DataRequestRaw.clear();
-        requested = false;
-        APReload::run();
-        APTraps::reset();
-        UpdateMissing();
-
-        APLogger::print(__FUNCTION__" complete\n");
-    }
-
-    void ItemClear()
-    {
-        APLogger::print("Client: reset\n");
-        reset();
-    }
-
-    void ItemRecv(int64_t itemID, bool notify)
-    {
-        switch (itemID) {
-            case 1:
-                leekHave += 1;
-                UpdateMissing();
-                break;
-            case 2:
-                break; // Filler
-            case 3:
-                APDeathLink::recvHP();
-                break;
-            case 4:
-                APTraps::touchHidden();
-                break;
-            case 5:
-                APTraps::touchSudden();
-                break;
-            case 9:
-                APTraps::touchIcon();
-                break;
-            default:
-                if (itemID >= 10) {
-                    PushRecvID(itemID / 10);
-                    APHints::updateByItemName(item_ap_id_to_name[itemID]);
-                }
-        }
     }
 
     void PushRecvID(int64_t songID)
@@ -279,11 +253,6 @@ namespace APClient
             recvIDs.begin(), recvIDs.end(),
             std::back_inserter(missingIDs)
         );
-    }
-
-    void LocationChecked(int64_t locationID)
-    {
-        CheckedLocations.push_back(locationID);
     }
 
     void LocationSend(int64_t pvID)
@@ -320,14 +289,51 @@ namespace APClient
         APLog += text;
     }
 
+    // Server messages
+
+    void DataRequest(const std::string key, std::function<void(std::string raw)> callback)
+    {
+        std::pair<AP_GetServerDataRequest, std::function<void(std::string raw)>> pair;
+
+        AP_GetServerDataRequest req;
+        req.key = key;
+        req.value = new std::string;
+        req.type = AP_DataType::Raw;
+        req.status = AP_RequestStatus::Pending;
+
+        pair.first = req;
+        pair.second = callback;
+
+        DataRequests.push_back(pair);
+
+        AP_GetServerData(&DataRequests.back().first);
+    }
+
     void CheckMessages()
     {
         if (AP_GetConnectionStatus() != AP_ConnectionStatus::Authenticated)
             return;
 
+        if (DataRequests.size() > 0) {
+            for (auto &[req, callback] : DataRequests) {
+                if (req.status == AP_RequestStatus::Pending) // What about stuck pending?
+                    continue;
+
+                //if (req.status == AP_RequestStatus::Error)
+
+                if (req.status == AP_RequestStatus::Done) {
+                    std::string value = *(std::string*)req.value;
+                    if (req.type == AP_DataType::Raw)
+                        callback(value);
+                }
+
+                free(req.value);
+                DataRequests.clear(); // TODO: conditional remove
+            }
+        }
+
         // No potential crashes here.
         LoadDatapackage();
-        GetSlotData();
 
         if (AP_IsMessagePending()) {
             AP_Message* msg = AP_GetLatestMessage();
@@ -378,7 +384,7 @@ namespace APClient
             return false;
         }
 
-        std::ifstream datapackage(LocalPath / ".datapkg-cache" / ("HatsuneMikuProjectDivaMegaMix-" + DatapackageChecksum + ".json"));
+        std::ifstream datapackage(BasePath / ".datapkg-cache" / ("HatsuneMikuProjectDivaMegaMix-" + DatapackageChecksum + ".json"));
 
         if (!datapackage.is_open())
             return false;
@@ -395,6 +401,7 @@ namespace APClient
             location_id_to_name[(int64_t)el.value()] = el.key();
 
         datapackageLoaded = true;
+
         return true;
     }
 
@@ -441,8 +448,11 @@ namespace APClient
             else
             {
                 if (ImGui::Button("Disconnect")) {
-                    reset();
                     AP_Shutdown();
+                    reset();
+
+                    if (!ImGui::GetIO().KeyShift)
+                        APReload::run();
                 }
 
                 ImGui::SameLine();

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -435,8 +435,7 @@ namespace APClient
             }
             else
             {
-                if (ImGui::Button("Disconnect"))
-                {
+                if (ImGui::Button("Disconnect")) {
                     reset();
                     AP_Shutdown();
                 }
@@ -447,6 +446,12 @@ namespace APClient
                 ImGui::SameLine();
                 if (ImGui::Button("Reload"))
                     APReload::run();
+
+                if (ImGui::IsItemHovered()) {
+                    ImGui::BeginTooltip();
+                    ImGui::Text("Reload key: %s", APReload::reloadVal);
+                    ImGui::EndTooltip();
+                }
 
                 ImGui::Separator();
 

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -130,6 +130,7 @@ namespace APClient
             std::sort(seedIDs.begin(), seedIDs.end());
         }
 
+        ImGui::SetWindowFocus("Client");
         APReload::run();
         APTraps::reset();
         UpdateMissing();
@@ -407,137 +408,134 @@ namespace APClient
 
     void ImGuiTab()
     {
-        if (ImGui::BeginTabItem("Client")) {
-            if (AP_GetConnectionStatus() != AP_ConnectionStatus::Authenticated)
-            {
-                if (AP_IsInit())
-                    ImGui::BeginDisabled();
+        //if (ImGui::BeginTabItem("Client")) {
+        if (AP_GetConnectionStatus() != AP_ConnectionStatus::Authenticated)
+        {
+            if (AP_IsInit())
+                ImGui::BeginDisabled();
 
-                ImGui::InputText("Slot Name", slotName, sizeof(slotName));
-                ImGui::InputText("Server", slotServer, sizeof(slotServer), !hideServer ? 0 : ImGuiInputTextFlags_Password);
-                if (ImGui::BeginPopupContextItem("##hideServer")) {
-                    ImGui::MenuItem("Hide server", NULL, &hideServer);
-                    ImGui::EndPopup();
-                }
-                ImGui::SameLine();
-                HelpMarker(
-                    "Server address must have the port number.\nRight-click input to toggle visibility."
-                    "\n\nExample addresses:\n archipelago.gg:38281\n localhost:38281\n 127.0.0.1:38281"
-                );
-
-                ImGui::InputText("Password", slotPassword, sizeof(slotPassword), ImGuiInputTextFlags_Password);
-
-                if (AP_IsInit())
-                    ImGui::EndDisabled();
-
-                bool disconnected = AP_GetConnectionStatus() == AP_ConnectionStatus::Disconnected;
-                bool refused = AP_GetConnectionStatus() == AP_ConnectionStatus::ConnectionRefused;
-
-                if (disconnected || refused)
-                    if (!AP_IsInit()) {
-                        if (ImGui::Button("Connect"))
-                            connect();
-                    }
-                    else {
-                        if (ImGui::Button("Cancel"))
-                            AP_Shutdown();
-                        ImGui::SameLine();
-                        ImGui::Text(refused ? "Wrong Name/Server/Password" : "Connecting...");
-                    }
+            ImGui::InputText("Slot Name", slotName, sizeof(slotName));
+            ImGui::InputText("Server", slotServer, sizeof(slotServer), !hideServer ? 0 : ImGuiInputTextFlags_Password);
+            if (ImGui::BeginPopupContextItem("##hideServer")) {
+                ImGui::MenuItem("Hide server", nullptr, &hideServer);
+                ImGui::EndPopup();
             }
-            else
-            {
-                if (ImGui::Button("Disconnect")) {
-                    AP_Shutdown();
-                    reset();
+            ImGui::SameLine();
+            HelpMarker(
+                "Server address must have the port number.\nRight-click input to toggle visibility."
+                "\n\nExample addresses:\n archipelago.gg:38281\n localhost:38281\n 127.0.0.1:38281"
+            );
 
-                    if (!ImGui::GetIO().KeyShift)
-                        APReload::run();
-                }
+            ImGui::InputText("Password", slotPassword, sizeof(slotPassword), ImGuiInputTextFlags_Password);
 
-                ImGui::SameLine();
-                ImGui::Text("Connected as %s", slotName);
+            if (AP_IsInit())
+                ImGui::EndDisabled();
 
-                ImGui::SameLine();
-                if (ImGui::Button("Reload"))
-                    APReload::run();
+            bool disconnected = AP_GetConnectionStatus() == AP_ConnectionStatus::Disconnected;
+            bool refused = AP_GetConnectionStatus() == AP_ConnectionStatus::ConnectionRefused;
 
-                if (ImGui::IsItemHovered()) {
-                    ImGui::BeginTooltip();
-                    ImGui::Text("Reload key: %s", APReload::reloadVal);
-                    ImGui::EndTooltip();
-                }
-
-                ImGui::Separator();
-
-                ImGui::BeginChild("APLog", ImVec2(0, 250));
-
-                if (APLogCopyMode) {
-                    ImGui::InputTextMultiline(
-                        "##APLogMulti",
-                        (char*)APLog.c_str(),
-                        APLog.size() + 1,
-                        ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y),
-                        ImGuiInputTextFlags_ReadOnly | ImGuiInputTextFlags_WordWrap
-                    );
+            if (disconnected || refused)
+                if (!AP_IsInit()) {
+                    if (ImGui::Button("Connect"))
+                        connect();
                 }
                 else {
-                    ImGui::BeginChild("APLogUnformatted");
-
-                    ImGui::PushTextWrapPos(0.0f);
-
-                    std::istringstream stream(APLog);
-                    std::string line;
-
-                    while (std::getline(stream, line)) {
-                        ImGui::TextUnformatted(line.c_str());
-                    }
-
-                    ImGui::PopTextWrapPos();
-
-                    if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
-                        ImGui::SetScrollHereY(1.0f);
-
-                    ImGui::EndChild();
+                    if (ImGui::Button("Cancel"))
+                        AP_Shutdown();
+                    ImGui::SameLine();
+                    ImGui::Text(refused ? "Wrong Name/Server/Password" : "Connecting...");
                 }
+        }
+        else
+        {
+            if (ImGui::Button("Disconnect")) {
+                AP_Shutdown();
+                reset();
 
-                if (ImGui::BeginPopupContextItem("##xx")) {
-                    ImGui::MenuItem("Copy mode (no autoscroll)", NULL, &APLogCopyMode);
-                    if (ImGui::MenuItem("Clear")) APLog.clear();
-                    ImGui::EndPopup();
-                }
-
-                ImGui::EndChild();
-
-                ImGui::Separator();
-
-                static bool refocus = false;
-                if (refocus) {
-                    refocus = false;
-                    ImGui::SetKeyboardFocusHere();
-                }
-
-                if (ImGui::InputText("##APsay", say, sizeof(say), ImGuiInputTextFlags_EnterReturnsTrue))
-                {
-                    refocus = true;
-                    if (strlen(say) > 0) {
-                        AP_Say(std::string(say));
-                        say[0] = '\0';
-                    }
-                }
-
-                ImGui::SameLine();
-                ImGui::Text("%d / %d Leeks", leekHave, leekNeed);
-
-                // TODO: Relocate
-                std::string goalTip = "Goal song: " + item_ap_id_to_name[victoryID] + "\n"
-                                      "Clear grade needed: " + (std::string)diffs[clearGrade - 1];
-
-                ImGui::SameLine();
-                HelpMarker(goalTip.c_str());
+                if (!ImGui::GetIO().KeyShift)
+                    APReload::run();
             }
 
-            ImGui::EndTabItem();
+            ImGui::SameLine();
+            ImGui::Text("Connected as %s", slotName);
+
+            ImGui::SameLine();
+            if (ImGui::Button("Reload"))
+                APReload::run();
+
+            if (ImGui::IsItemHovered()) {
+                ImGui::BeginTooltip();
+                ImGui::Text("Reload key: %s", APReload::reloadVal);
+                ImGui::EndTooltip();
+            }
+
+            ImGui::Separator();
+
+            ImGui::BeginChild("APLog", ImVec2(0, ImGui::GetContentRegionAvail().y - (ImGui::GetFrameHeightWithSpacing() * 1.2f)));
+
+            if (APLogCopyMode) {
+                ImGui::InputTextMultiline(
+                    "##APLogMulti",
+                    (char*)APLog.c_str(),
+                    APLog.size() + 1,
+                    ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y),
+                    ImGuiInputTextFlags_ReadOnly | ImGuiInputTextFlags_WordWrap
+                );
+            }
+            else {
+                ImGui::BeginChild("APLogUnformatted");
+
+                ImGui::PushTextWrapPos(0.0f);
+
+                std::istringstream stream(APLog);
+                std::string line;
+
+                while (std::getline(stream, line)) {
+                    ImGui::TextUnformatted(line.c_str());
+                }
+
+                ImGui::PopTextWrapPos();
+
+                if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
+                    ImGui::SetScrollHereY(1.0f);
+
+                ImGui::EndChild();
+            }
+
+            if (ImGui::BeginPopupContextItem("##xx")) {
+                ImGui::MenuItem("Copy mode (no autoscroll)", nullptr, &APLogCopyMode);
+                if (ImGui::MenuItem("Clear")) APLog.clear();
+                ImGui::EndPopup();
+            }
+
+            ImGui::EndChild();
+
+            ImGui::Separator();
+
+            static bool refocus = false;
+            if (refocus) {
+                refocus = false;
+                ImGui::SetKeyboardFocusHere();
+            }
+
+            if (ImGui::InputText("##APsay", say, sizeof(say), ImGuiInputTextFlags_EnterReturnsTrue))
+            {
+                refocus = true;
+                if (strlen(say) > 0) {
+                    AP_Say(std::string(say));
+                    say[0] = '\0';
+                }
+            }
+
+            ImGui::SameLine();
+            ImGui::Text("%d / %d Leeks", leekHave, leekNeed);
+
+            // TODO: Relocate
+            std::string goalTip = "Goal song: " + item_ap_id_to_name[victoryID] + "\n"
+                                    "Clear grade needed: " + (std::string)diffs[clearGrade - 1];
+
+            ImGui::SameLine();
+            HelpMarker(goalTip.c_str());
         }
     }
 }

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -137,6 +137,7 @@ namespace APClient
 
         seedIDs.clear();
         recvIDs.clear();
+        missingIDs.clear();
         CheckedLocations.clear();
 
         say[0] = '\0';

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -412,6 +412,11 @@ namespace APClient
                     ImGui::MenuItem("Hide server", NULL, &hideServer);
                     ImGui::EndPopup();
                 }
+                ImGui::SameLine();
+                HelpMarker(
+                    "Server address must have the port number.\nRight-click input to toggle visibility."
+                    "\n\nExample addresses:\n archipelago.gg:38281\n localhost:38281\n 127.0.0.1:38281"
+                );
 
                 ImGui::InputText("Password", slotPassword, sizeof(slotPassword), ImGuiInputTextFlags_Password);
 

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -155,13 +155,13 @@ namespace APClient
             APDeathLink::recvHP();
             break;
         case 4:
-            APTraps::touchHidden();
+            if (notify) APTraps::touchHidden();
             break;
         case 5:
-            APTraps::touchSudden();
+            if (notify) APTraps::touchSudden();
             break;
         case 9:
-            APTraps::touchIcon();
+            if (notify) APTraps::touchIcon();
             break;
         default:
             if (itemID >= 10) {

--- a/APClient.cpp
+++ b/APClient.cpp
@@ -409,7 +409,7 @@ namespace APClient
                 ImGui::InputText("Slot Name", slotName, sizeof(slotName));
                 ImGui::InputText("Server", slotServer, sizeof(slotServer), !hideServer ? 0 : ImGuiInputTextFlags_Password);
                 if (ImGui::BeginPopupContextItem("##hideServer")) {
-                    ImGui::Checkbox("Hide", &hideServer);
+                    ImGui::MenuItem("Hide server", NULL, &hideServer);
                     ImGui::EndPopup();
                 }
 
@@ -458,15 +458,17 @@ namespace APClient
                 ImGui::BeginChild("APLog", ImVec2(0, 250));
 
                 if (APLogCopyMode) {
-                    ImGui::InputTextMultiline("##APLogMulti", (char*)APLog.c_str(), sizeof(APLog), ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y), ImGuiInputTextFlags_ReadOnly | ImGuiInputTextFlags_WordWrap);
-
-                    // TODO: dedupe
-                    if (ImGui::BeginPopupContextItem("##xx")) {
-                        ImGui::Checkbox("Copy mode (no autoscroll)", &APLogCopyMode);
-                        ImGui::EndPopup();
-                    }
+                    ImGui::InputTextMultiline(
+                        "##APLogMulti",
+                        (char*)APLog.c_str(),
+                        APLog.size() + 1,
+                        ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y),
+                        ImGuiInputTextFlags_ReadOnly | ImGuiInputTextFlags_WordWrap
+                    );
                 }
                 else {
+                    ImGui::BeginChild("APLogUnformatted");
+
                     ImGui::PushTextWrapPos(0.0f);
 
                     std::istringstream stream(APLog);
@@ -480,14 +482,17 @@ namespace APClient
 
                     if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
                         ImGui::SetScrollHereY(1.0f);
+
+                    ImGui::EndChild();
+                }
+
+                if (ImGui::BeginPopupContextItem("##xx")) {
+                    ImGui::MenuItem("Copy mode (no autoscroll)", NULL, &APLogCopyMode);
+                    if (ImGui::MenuItem("Clear")) APLog.clear();
+                    ImGui::EndPopup();
                 }
 
                 ImGui::EndChild();
-
-                if (ImGui::BeginPopupContextItem("##xx")) {
-                    ImGui::Checkbox("Copy mode (no autoscroll)", &APLogCopyMode);
-                    ImGui::EndPopup();
-                }
 
                 ImGui::Separator();
 

--- a/APClient.h
+++ b/APClient.h
@@ -27,7 +27,7 @@ namespace APClient
 
     char* getSlotName();
 
-    void config(const toml::v3::ex::parse_result& data);
+    void config(const toml::table& settings);
     void save(toml::table& settings);
     void reset();
 
@@ -36,15 +36,15 @@ namespace APClient
     void GetSlotData();
 
     void ItemClear();
-    void ItemRecv(int64_t, bool);
-    void PushRecvID(int64_t);
-    void LocationChecked(int64_t);
+    void ItemRecv(int64_t itemID, bool notify);
+    void PushRecvID(int64_t songID);
+    void LocationChecked(int64_t locationID);
     void LocationSend(int64_t pvID);
 
     void LogAppend(const std::string& text);
     void CheckMessages();
 
-    void RecvDeath(std::string, std::string);
+    void RecvDeath(std::string src, std::string cause);
 
     bool LoadDatapackage();
     void ImGuiTab();

--- a/APClient.h
+++ b/APClient.h
@@ -31,17 +31,11 @@ namespace APClient
     void save(toml::table& settings);
     void reset();
 
-    AP_RequestStatus ServerDataRequest_Raw(std::string key, AP_GetServerDataRequest& request, bool& requested, std::string& output);
-
-    void GetSlotData();
-
-    void ItemClear();
-    void ItemRecv(int64_t itemID, bool notify);
     void PushRecvID(int64_t songID);
-    void LocationChecked(int64_t locationID);
     void LocationSend(int64_t pvID);
 
     void LogAppend(const std::string& text);
+    void DataRequest(const std::string key, const std::function<void(std::string raw)> callback);
     void CheckMessages();
 
     void RecvDeath(std::string src, std::string cause);

--- a/APDeathLink.cpp
+++ b/APDeathLink.cpp
@@ -261,94 +261,90 @@ namespace APDeathLink
 
     void ImGuiTab()
     {
-        if (ImGui::BeginTabItem("Death Link")) {
-            if (devMode || HPdenominator > 1) {
-                float progress = (float)min(HPdenominator, (HPdenominator - HPnumerator)) / (float)HPdenominator;
-                char buf[8];
-                sprintf(buf, "%d / %d", HPnumerator, HPdenominator);
+        if (devMode || HPdenominator > 1) {
+            float progress = (float)min(HPdenominator, (HPdenominator - HPnumerator)) / (float)HPdenominator;
+            char buf[8];
+            sprintf(buf, "%d / %d", HPnumerator, HPdenominator);
 
-                ImGui::ProgressBar(progress, ImVec2(0.0f, 0.0f), buf);
-                ImGui::SameLine();
-                ImGui::Text("Progressive HP");
-
-                if (ImGui::Button("Reset##progReset"))
-                    HPtemp = 0;
-
-                ImGui::SameLine();
-                if (ImGui::Button("+1##progTemp+1"))
-                    HPtemp += 1;
-
-
-                ImGui::SameLine();
-                ImGui::Text("Temporary HP: %d+%d", HPreceived, HPtemp);
-
-                ImGui::SameLine();
-                HelpMarker("Temporarily increase available chunk count.\nResets when the next one is received.");
-
-                if (devMode)
-                    ImGui::SliderInt("Denominator", &HPdenominator, 1, 20);
-
-                ImGui::Separator();
-            }
-
-            ImGui::Checkbox("Death Link", &death_link);
+            ImGui::ProgressBar(progress, ImVec2(0.0f, 0.0f), buf);
             ImGui::SameLine();
-            HelpMarker("When you die on your own or fail to reach Grade Needed (not both), everyone with Death Link enabled dies.");
+            ImGui::Text("Progressive HP");
 
-            if (death_link) {
-                if (ImGui::SliderInt("Death Link Amnesty", &death_link_amnesty, 0, 20))
-                    death_link_amnesty_count = death_link_amnesty;
-                ImGui::SameLine();
-                HelpMarker("Amount of additional own deaths needed before sending one Death Link. 0 would be every death, 1 every other, etc.");
+            if (ImGui::Button("Reset##progReset"))
+                HPtemp = 0;
 
-                if (death_link_amnesty > 0) {
-                    char overlay[64];
-                    sprintf(overlay, "%d / %d deaths", death_link_amnesty - death_link_amnesty_count, death_link_amnesty);
-                    ImGui::ProgressBar(static_cast<float>(death_link_amnesty - death_link_amnesty_count) / static_cast<float>(death_link_amnesty), ImVec2(0,0), overlay);
-                }
+            ImGui::SameLine();
+            if (ImGui::Button("+1##progTemp+1"))
+                HPtemp += 1;
 
-                ImGui::SliderInt("Death Link Percent", &death_link_percent, 0, 100, "%d%%");
-                ImGui::SameLine();
-                HelpMarker("Percent of max HP to lose on receive.\n<100 for non-lethal, but makes Life Bonuses harder which may affect score by up to 2%.");
 
-                ImGui::SliderFloat("Death Link Safety", &death_link_safety, 0.0f, 30.0f, "%.1f seconds");
-                ImGui::SameLine();
-                HelpMarker("Seconds after receiving where dying does not send one out.");
+            ImGui::SameLine();
+            ImGui::Text("Temporary HP: %d+%d", HPreceived, HPtemp);
 
-                if (devMode)
-                {
-                    ImGui::Separator();
+            ImGui::SameLine();
+            HelpMarker("Temporarily increase available chunk count.\nResets when the next one is received.");
 
-                    if (ImGui::Button("100%")) {
-                        deathLinked = true;
-                        setHP(0);
-                    }
+            if (devMode)
+                ImGui::SliderInt("Denominator", &HPdenominator, 1, 20);
 
-                    ImGui::SameLine();
-                    if (ImGui::Button("+NoFail##100")) {
-                        deathLinked = true;
-                        WRITE_MEMORY(PvPlayData + 0x2D31D, bool, 0);
-                        setHP(0);
-                    }
+            ImGui::Separator();
+        }
 
-                    ImGui::SameLine();
-                    if (ImGui::Button("Recv"))
-                        run(true);
+        ImGui::Checkbox("Death Link", &death_link);
+        ImGui::SameLine();
+        HelpMarker("When you die on your own or fail to reach Grade Needed (not both), everyone with Death Link enabled dies.");
 
-                    ImGui::SameLine();
-                    if (ImGui::Button("+NoFail##recv")) {
-                        WRITE_MEMORY(PvPlayData + 0x2D31D, bool, 0);
-                        run(true);
-                    }
+        if (death_link) {
+            if (ImGui::SliderInt("Death Link Amnesty", &death_link_amnesty, 0, 20))
+                death_link_amnesty_count = death_link_amnesty;
+            ImGui::SameLine();
+            HelpMarker("Amount of additional own deaths needed before sending one Death Link. 0 would be every death, 1 every other, etc.");
 
-                    ImGui::SameLine();
-                    ImGui::Text("Linked: %d", deathLinked);
-                    ImGui::SameLine();
-                    HelpMarker("If 1/true, the cause of the death prevented a Death Link from being sent.\nFor example, dying in one hit or inside the safety window.");
-                }
+            if (death_link_amnesty > 0) {
+                char overlay[64];
+                sprintf(overlay, "%d / %d deaths", death_link_amnesty - death_link_amnesty_count, death_link_amnesty);
+                ImGui::ProgressBar(static_cast<float>(death_link_amnesty - death_link_amnesty_count) / static_cast<float>(death_link_amnesty), ImVec2(0,0), overlay);
             }
 
-            ImGui::EndTabItem();
+            ImGui::SliderInt("Death Link Percent", &death_link_percent, 0, 100, "%d%%");
+            ImGui::SameLine();
+            HelpMarker("Percent of max HP to lose on receive.\n<100 for non-lethal, but makes Life Bonuses harder which may affect score by up to 2%.");
+
+            ImGui::SliderFloat("Death Link Safety", &death_link_safety, 0.0f, 30.0f, "%.1f seconds");
+            ImGui::SameLine();
+            HelpMarker("Seconds after receiving where dying does not send one out.");
+
+            if (devMode)
+            {
+                ImGui::Separator();
+
+                if (ImGui::Button("100%")) {
+                    deathLinked = true;
+                    setHP(0);
+                }
+
+                ImGui::SameLine();
+                if (ImGui::Button("+NoFail##100")) {
+                    deathLinked = true;
+                    WRITE_MEMORY(PvPlayData + 0x2D31D, bool, 0);
+                    setHP(0);
+                }
+
+                ImGui::SameLine();
+                if (ImGui::Button("Recv"))
+                    run(true);
+
+                ImGui::SameLine();
+                if (ImGui::Button("+NoFail##recv")) {
+                    WRITE_MEMORY(PvPlayData + 0x2D31D, bool, 0);
+                    run(true);
+                }
+
+                ImGui::SameLine();
+                ImGui::Text("Linked: %d", deathLinked);
+                ImGui::SameLine();
+                HelpMarker("If 1/true, the cause of the death prevented a Death Link from being sent.\nFor example, dying in one hit or inside the safety window.");
+            }
         }
     }
 }

--- a/APDeathLink.cpp
+++ b/APDeathLink.cpp
@@ -232,7 +232,7 @@ namespace APDeathLink
             }
         }
 
-        if (deathLinked || !received)
+        if (!death_link || deathLinked || !received)
             return;
 
         lastDeathLink = now;

--- a/APDeathLink.cpp
+++ b/APDeathLink.cpp
@@ -11,9 +11,9 @@ namespace APDeathLink
     int death_link_percent = 100; // Percentage of max HP to lose on receive. "If at or below this, die."
     float death_link_safety = 10.0f; // Seconds after receiving a DL to avoid chain reaction DLs.
 
-    const uint64_t DivaGameHP = 0x1412C2330 + 0x2D234;
-    const uint64_t DivaGameTimer = 0x1412C2330 + 0x2C010;
-    const uint64_t DivaSafetyWidthPercent = 0x1412C2330 + 0x2D314;
+    const uint64_t DivaGameHP = PvPlayData + 0x2D234;
+    const uint64_t DivaGameTimer = PvPlayData + 0x2C010;
+    const uint64_t DivaSafetyWidthPercent = PvPlayData + 0x2D314;
 
     // Internal
     int death_link_amnesty_count = 0;
@@ -327,7 +327,7 @@ namespace APDeathLink
                     ImGui::SameLine();
                     if (ImGui::Button("+NoFail##100")) {
                         deathLinked = true;
-                        WRITE_MEMORY(0x1412C2330 + 0x2D31D, bool, 0);
+                        WRITE_MEMORY(PvPlayData + 0x2D31D, bool, 0);
                         setHP(0);
                     }
 
@@ -337,7 +337,7 @@ namespace APDeathLink
 
                     ImGui::SameLine();
                     if (ImGui::Button("+NoFail##recv")) {
-                        WRITE_MEMORY(0x1412C2330 + 0x2D31D, bool, 0);
+                        WRITE_MEMORY(PvPlayData + 0x2D31D, bool, 0);
                         run(true);
                     }
 

--- a/APDeathLink.h
+++ b/APDeathLink.h
@@ -20,12 +20,12 @@ namespace APDeathLink
 	void save(toml::table& settings);
 	void reset();
 	void check_fail();
-	void run(bool);
+	void run(bool received);
 	void runAmnesty(); // "Send death", but after checking amnesty.
 	void recvHP();
 	void prog_hp_update();
 	void prog_hp_reset();
-	void setHP(uint8_t);
+	void setHP(uint8_t HP);
 
 	void ImGuiTab();
 };

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -86,6 +86,7 @@ namespace APGUI
             ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
             return;
         }
+        ShowCursor(true); // If the GUI is visible, the cursor should be too.
         ImGui::GetStyle().Alpha = ingame ? alphaIngame : alphaDefault;
 
         if (showImGuiDemo)

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -86,7 +86,7 @@ namespace APGUI
             ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
             return;
         }
-        ShowCursor(true); // If the GUI is visible, the cursor should be too.
+        while (ShowCursor(true) < 0); // If the GUI is visible, the cursor should be too.
         ImGui::GetStyle().Alpha = ingame ? alphaIngame : alphaDefault;
 
         if (showImGuiDemo)

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -155,15 +155,16 @@ namespace APGUI
             return;
 
         ImGui::OpenPopup("Archipelago Mod - First Run");
-        if (ImGui::BeginPopupModal("Archipelago Mod - First Run", NULL, ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoResize))
+        if (ImGui::BeginPopupModal("Archipelago Mod - First Run", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoResize))
         {
             ImGui::SetWindowFocus("Archipelago Mod - First Run");
 
-            std::string warn1 = "After connecting, press the reload key while on the song list to get new songs.\n"
-                "Songs can be cleared on any available difficulty for the same checks.\n\n";
-            ImGui::Text("%s", warn1.c_str());
-
-            ImGui::Text("\nCurrent reload key: %s", APReload::reloadVal.c_str());
+            ImGui::Text("This mod is for use with");
+            ImGui::SameLine();
+            ImGui::TextLinkOpenURL("Archipelago", "https://archipelago.gg");
+            ImGui::SameLine(0.0f, 0.0f);
+            ImGui::Text(", a multi-game randomizer.");
+            ImGui::Text("\nAdditional help can be found in its Discord linked on the website.");
 
             ImGui::Separator();
             if (ImGui::Button("Okay"))
@@ -185,6 +186,16 @@ namespace APGUI
             APSettings::ImGuiTab();
 
             ImGui::Separator();
+
+            if (ImGui::CollapsingHeader("Help")) {
+                /*if (ImGui::Button("Show first run warning")) {
+                    showWarning = true;
+                    warning();
+                }*/
+                ImGui::TextLinkOpenURL("Archipelago website", "https://archipelago.gg");
+                ImGui::TextLinkOpenURL("Project Diva AP documentation", "https://github.com/Cynichill/DivaAPworld/tree/main/docs");
+                ImGui::TextLinkOpenURL("Project Diva AP Discord thread", "https://discord.com/channels/731205301247803413/1241134454391443580");
+            }
 
             APReload::ImGuiTab();
 

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -86,7 +86,7 @@ namespace APGUI
             ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
             return;
         }
-        while (ShowCursor(true) < 0); // If the GUI is visible, the cursor should be too.
+        while (ShowCursor(true) < 1); // If the GUI is visible, the cursor should be too.
         ImGui::GetStyle().Alpha = ingame ? alphaIngame : alphaDefault;
 
         if (showImGuiDemo)

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -12,12 +12,23 @@ namespace APGUI
 {
     // Configurables
 
-    bool auto_hide_client = true; // Hide Client during gameplay
     bool& devMode = APClient::devMode;
+    bool enableDocking = false;
+    bool autoHideClient = true; // Hide Client during gameplay
     bool showWarning = true; // First run warning
+    float alphaDefault = 1.0f;
+    float alphaIngame = 1.0f;
 
     bool showImGuiDemo = false;
     bool firstFrame = true;
+
+    // TODO: Move names into own namespace?
+    std::vector<std::pair<const char*, std::function<void()>>> windows = {
+        { "Tracker", APIDHandler::ImGuiTab },
+        { "Hints", APHints::ImGuiTab },
+        { "Death Link", APDeathLink::ImGuiTab },
+        { "Traps", APTraps::ImGuiTab },
+    };
 
     ID3D11Device* g_Device = nullptr;
     ID3D11DeviceContext* g_Context = nullptr;
@@ -41,7 +52,7 @@ namespace APGUI
         ImGui::CreateContext();
         ImGui::StyleColorsDark();
 
-        ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+        ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_DockingEnable | ImGuiConfigFlags_NavEnableKeyboard;
 
         ImGuiStyle& style = ImGui::GetStyle();
         style.ScaleAllSizes(main_scale);
@@ -59,8 +70,13 @@ namespace APGUI
         ImGui_ImplWin32_NewFrame();
         ImGui::NewFrame();
 
+        // Weird focus behavior on create so keep every frame.
+        ImGui::DockSpaceOverViewport(0, nullptr, ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_NoDockingOverCentralNode);
+
         // auto hide client when in game, not paused, not on results
-        if (auto_hide_client && *(bool*)PvPlayData && !*(bool*)(PvPlayData + 0x1) && !*(bool*)(PvPlayData + 0x2D17D)) {
+        bool ingame = *(bool*)PvPlayData && !*(bool*)(PvPlayData + 0x1) && !*(bool*)(PvPlayData + 0x2D17D);
+        if (ingame && autoHideClient) {
+            ImGui::SetWindowFocus(nullptr);
             ImGui::GetIO().WantCaptureKeyboard = false;
             ImGui::GetIO().WantCaptureMouse = false;
             ImGui::SetNextFrameWantCaptureKeyboard(false);
@@ -70,44 +86,81 @@ namespace APGUI
             ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
             return;
         }
+        ImGui::GetStyle().Alpha = ingame ? alphaIngame : alphaDefault;
 
         if (showImGuiDemo)
             ImGui::ShowDemoWindow();
 
-        ImGui::Begin("Archipelago Mod###APClient", NULL,
-                    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing);
+        ImGuiID client_dockspace_id = ImGui::GetID("client");
+        //ImGui::DockSpace(client_dockspace_id);
 
-        if (ImGui::BeginTabBar("APTabs" /*, ImGuiTabBarFlags_Reorderable*/)) {
+        if (enableDocking) {
+            ImGui::SetNextWindowDockID(client_dockspace_id, ImGuiCond_FirstUseEver);
+            ImGui::Begin("Client", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
             APClient::ImGuiTab();
+            ImGui::End();
+        }
+        else {
+            ImGuiWindowFlags flags = ImGuiWindowFlags_NoFocusOnAppearing;
+            //if (firstFrame)
+            //flags |= ImGuiWindowFlags_AlwaysAutoResize;
+            ImGui::SetNextWindowSizeConstraints(ImVec2(360, 180), ImVec2(FLT_MAX, FLT_MAX));
+            ImGui::Begin("Archipelago Mod", nullptr, flags);
 
-            if (devMode || AP_GetConnectionStatus() == AP_ConnectionStatus::Authenticated) {
-                APIDHandler::ImGuiTab();
-                APHints::ImGuiTab();
-                APDeathLink::ImGuiTab();
-                APTraps::ImGuiTab();
+            ImGui::BeginTabBar("##clientTabs");
+            if (ImGui::BeginTabItem("Client", nullptr/*, ImGuiTabItemFlags_SetSelected */)) {
+                APClient::ImGuiTab();
+                ImGui::EndTabItem();
             }
-
-            APGUI::ImGuiTab();
-
-            ImGui::EndTabBar();
         }
 
-        if (!firstFrame)
-        {
+        if (devMode || AP_GetConnectionStatus() == AP_ConnectionStatus::Authenticated) {
+            for (const auto& [name, contents] : windows) {
+                if (enableDocking) {
+                    ImGui::SetNextWindowDockID(client_dockspace_id, ImGuiCond_FirstUseEver);
+                    ImGui::Begin(name, nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
+                    contents();
+                    ImGui::End();
+                }
+                else {
+                    if (ImGui::BeginTabItem(name)) {
+                        contents();
+                        ImGui::EndTabItem();
+                    }
+                }
+            }
+        }
+
+        if (firstFrame) {
+            firstFrame = false;
+            ImGui::SetWindowFocus("Client");
+            ImGui::SetWindowFocus(0);
+        }
+        else {
             ImVec2 display_size = ImGui::GetIO().DisplaySize;
             ImVec2 window_pos = ImVec2(display_size.x - ImGui::GetWindowWidth() - (display_size.x * static_cast<float>(0.01)),
-                                       display_size.y - ImGui::GetWindowHeight() - (display_size.y * static_cast<float>(0.01)));
+                display_size.y - ImGui::GetWindowHeight() - (display_size.y * static_cast<float>(0.01)));
 
             ImGui::SetWindowPos(window_pos, ImGuiCond_FirstUseEver);
         }
+
+        if (enableDocking) {
+            ImGui::SetNextWindowDockID(client_dockspace_id, ImGuiCond_FirstUseEver);
+            ImGui::Begin("Advanced", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
+            APGUI::ImGuiTab();
+            ImGui::End();
+        }
         else {
-            firstFrame = false;
-            ImGui::SetWindowFocus(0);
+            if (ImGui::BeginTabItem("Advanced")) {
+                APGUI::ImGuiTab();
+                ImGui::EndTabItem();
+            }
+
+            ImGui::EndTabBar();
+            ImGui::End();
         }
 
         warning();
-
-        ImGui::End();
 
         ImGui::Render();
         ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
@@ -119,22 +172,31 @@ namespace APGUI
         if (settings.contains("gui") && settings["gui"].is_table())
             section = *settings["gui"].as_table();
 
-        auto_hide_client = section["auto_hide_client"].value_or(true);
+        autoHideClient = section["autoHideClient"].value_or(true);
         showWarning = section["warning"].value_or(true);
+        enableDocking = section["docking"].value_or(false);
 
         float main_scale = ImGui_ImplWin32_GetDpiScaleForMonitor(::MonitorFromPoint(POINT{ 0, 0 }, MONITOR_DEFAULTTOPRIMARY));
-        auto scale = section["font_scale"].value_or(main_scale);
+        auto scale = section["fontScale"].value_or(main_scale);
         scale = std::clamp(scale, 0.75f, 4.0f);
-
         ImGui::GetStyle().FontScaleDpi = scale;
+
+        float _alphaDefault = section["alphaDefault"].value_or(1.0f);
+        alphaDefault = std::clamp(_alphaDefault, 0.5f, 1.0f);
+
+        float _alphaIngame = section["alphaIngame"].value_or(1.0f);
+        alphaIngame = std::clamp(_alphaIngame, 0.1f, 1.0f);
     }
 
     void save(toml::table &settings)
     {
         toml::table config;
-        config.insert("auto_hide_client", auto_hide_client);
-        config.insert("font_scale", ImGui::GetStyle().FontScaleDpi);
+        config.insert("autoHideClient", autoHideClient);
+        config.insert("docking", enableDocking);
+        config.insert("fontScale", ImGui::GetStyle().FontScaleDpi);
         config.insert("warning", showWarning);
+        config.insert("alphaDefault", alphaDefault);
+        config.insert("alphaIngame", alphaIngame);
 
         settings.insert("gui", config);
     }
@@ -145,7 +207,7 @@ namespace APGUI
             return;
 
         ImGui::OpenPopup("Archipelago Mod - First Run");
-        if (ImGui::BeginPopupModal("Archipelago Mod - First Run", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoResize))
+        if (ImGui::BeginPopupModal("Archipelago Mod - First Run", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoResize))
         {
             ImGui::SetWindowFocus("Archipelago Mod - First Run");
 
@@ -171,87 +233,90 @@ namespace APGUI
 
     void ImGuiTab()
     {
-        if (ImGui::BeginTabItem("Advanced")) {
-            ImGui::Checkbox("Hide window during gameplay", &auto_hide_client);
-            APSettings::ImGuiTab();
+        APSettings::ImGuiTab();
 
-            ImGui::Separator();
+        ImGui::Separator();
 
-            if (ImGui::CollapsingHeader("Help")) {
-                /*if (ImGui::Button("Show first run warning")) {
-                    showWarning = true;
-                    warning();
+        if (ImGui::CollapsingHeader("Help")) {
+            /*if (ImGui::Button("Show first run warning")) {
+                showWarning = true;
+                warning();
+            }*/
+            ImGui::TextLinkOpenURL("Archipelago website", "https://archipelago.gg");
+            ImGui::TextLinkOpenURL("Project Diva AP documentation", "https://github.com/Cynichill/DivaAPworld/tree/main/docs");
+            ImGui::TextLinkOpenURL("Project Diva AP Discord thread", "https://discord.com/channels/731205301247803413/1241134454391443580");
+        }
+
+        APReload::ImGuiTab();
+
+        if (ImGui::CollapsingHeader("Styling")) {
+            ImGui::Checkbox("Hide during gameplay", &autoHideClient);
+            ImGui::Checkbox("Enable docking support", &enableDocking);
+            ImGui::Checkbox("Show ImGui demo", &showImGuiDemo);
+            ImGui::DragFloat("Font DPI Scale", &ImGui::GetStyle().FontScaleDpi, 0.02f, 0.75f, 4.0f, "%.02f");
+            ImGui::SameLine();
+            HelpMarker("1.25 recommended for 1440p\n1.75 recommended for 4K");
+
+            if (ImGui::DragFloat("Default Alpha", &alphaDefault, 0.01f, 0.5f, 1.0f, "%.2f"))
+                alphaDefault = max(alphaDefault, 0.5f); // unlike the demo, actually prevent a 0
+
+            if (ImGui::DragFloat("In-game Alpha", &alphaIngame, 0.01f, 0.1f, 1.0f, "%.2f"))
+                alphaIngame = max(alphaIngame, 0.1f);
+
+            ImGui::SameLine();
+            HelpMarker("If not hidden during gameplay, lower alpha to this instead.");
+        }
+
+        if (ImGui::CollapsingHeader("Developer Mode")) {
+            ImGui::Checkbox("Enable Developer Mode", &devMode);
+            ImGui::SameLine();
+            HelpMarker("Dangerous! For the curious or the stuck.");
+
+            if (devMode) {
+                // Easy crashes with other mods that already freopen'd to stdout
+                /*if (!GetConsoleWindow() && ImGui::Button("Console")) {
+                    AllocConsole();
+                    APLogger::print("DO NOT CLOSE THIS WINDOW OR THE GAME WILL CLOSE\n");
                 }*/
-                ImGui::TextLinkOpenURL("Archipelago website", "https://archipelago.gg");
-                ImGui::TextLinkOpenURL("Project Diva AP documentation", "https://github.com/Cynichill/DivaAPworld/tree/main/docs");
-                ImGui::TextLinkOpenURL("Project Diva AP Discord thread", "https://discord.com/channels/731205301247803413/1241134454391443580");
-            }
 
-            APReload::ImGuiTab();
+                if (ImGui::Button("Reset")) {
+                    APClient::seedIDs.clear();
+                    APClient::recvIDs.clear();
+                    APClient::missingIDs.clear();
 
-            if (ImGui::CollapsingHeader("Styling")) {
-                ImGui::Checkbox("Show ImGui demo", &showImGuiDemo);
-                ImGui::DragFloat("Font DPI Scale", &ImGui::GetStyle().FontScaleDpi, 0.02f, 0.75f, 4.0f, "%.02f");
-                ImGui::SameLine();
-                HelpMarker("1.25 recommended for 1440p\n1.75 recommended for 4K");
-
-                if (ImGui::DragFloat("Global Alpha", &ImGui::GetStyle().Alpha, 0.01f, 0.50f, 1.0f, "%.2f"))
-                    ImGui::GetStyle().Alpha = max(ImGui::GetStyle().Alpha, 0.5f); // unlike the demo, actually prevent a 0
-            }
-
-            if (ImGui::CollapsingHeader("Developer Mode")) {
-                ImGui::Checkbox("Enable Developer Mode", &devMode);
-                ImGui::SameLine();
-                HelpMarker("Dangerous! For the curious or the stuck.");
-
-                if (devMode) {
-                    // Easy crashes with other mods that already freopen'd to stdout
-                    /*if (!GetConsoleWindow() && ImGui::Button("Console")) {
-                        AllocConsole();
-                        APLogger::print("DO NOT CLOSE THIS WINDOW OR THE GAME WILL CLOSE\n");
-                    }*/
-
-                    if (ImGui::Button("Reset")) {
-                        APClient::seedIDs.clear();
-                        APClient::recvIDs.clear();
-                        APClient::missingIDs.clear();
-
-                        APReload::run();
-                    }
-
-                    ImGui::SameLine();
-                    if (ImGui::Button("Sample Random IDs")) {
-                        APClient::seedIDs.clear();
-                        APClient::seedIDs.push_back(0); // Prevent seedIDs == recvIDs
-                        APClient::recvIDs.clear();
-
-                        // This doesn't need good random. The biggest issue it will have is picking a valid ID.
-                        for (int i = 0; i < 500; ++i)
-                        {
-                            int id = rand() % 10000 + 1;
-                            APClient::seedIDs.push_back(id);
-
-                            if (rand() % (rand() % 10 + 1) == 1)
-                                APClient::PushRecvID(id);
-                        }
-
-                        APReload::run();
-                    }
-
-                    ImGui::SameLine();
-                    HelpMarker("Fills the IDHandler with \"random\" IDs up to 10000.\n"
-                        "Try toggling Freeplay from the Tracker tab.\n"
-                        "Effectively an offline Archipelago."
-                    );
-
-                    ImGui::SameLine();
-                    ImGui::Text("%d/%d recv/seed", APClient::recvIDs.size(), APClient::seedIDs.size());
-
-                    APLogger::ImGuiTab();
+                    APReload::run();
                 }
-            }
 
-            ImGui::EndTabItem();
+                ImGui::SameLine();
+                if (ImGui::Button("Sample Random IDs")) {
+                    APClient::seedIDs.clear();
+                    APClient::seedIDs.push_back(0); // Prevent seedIDs == recvIDs
+                    APClient::recvIDs.clear();
+
+                    // This doesn't need good random. The biggest issue it will have is picking a valid ID.
+                    for (int i = 0; i < 500; ++i)
+                    {
+                        int id = rand() % 10000 + 1;
+                        APClient::seedIDs.push_back(id);
+
+                        if (rand() % (rand() % 10 + 1) == 1)
+                            APClient::PushRecvID(id);
+                    }
+
+                    APReload::run();
+                }
+
+                ImGui::SameLine();
+                HelpMarker("Fills the IDHandler with \"random\" IDs up to 10000.\n"
+                    "Try toggling Freeplay from the Tracker tab.\n"
+                    "Effectively an offline Archipelago."
+                );
+
+                ImGui::SameLine();
+                ImGui::Text("%d/%d recv/seed", APClient::recvIDs.size(), APClient::seedIDs.size());
+
+                APLogger::ImGuiTab();
+            }
         }
     }
 }

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -200,13 +200,9 @@ namespace APGUI
             }
 
             if (ImGui::CollapsingHeader("Developer Mode")) {
-                if (ImGui::Checkbox("Enable Developer Mode", &devMode)) devMode = false;
-                if (ImGui::BeginPopupContextItem("##xx")) {
-                    if (ImGui::MenuItem("Are you sure?##xx"))
-                        devMode = !devMode;
-
-                    ImGui::EndPopup();
-                }
+                ImGui::Checkbox("Enable Developer Mode", &devMode);
+                ImGui::SameLine();
+                HelpMarker("Dangerous! For the curious or the stuck.");
 
                 if (devMode) {
                     // Easy crashes with other mods that already freopen'd to stdout
@@ -244,7 +240,9 @@ namespace APGUI
 
                     ImGui::SameLine();
                     HelpMarker("Fills the IDHandler with \"random\" IDs up to 10000.\n"
-                        "Try toggling Freeplay from the Tracker tab.");
+                        "Try toggling Freeplay from the Tracker tab.\n"
+                        "Effectively an offline Archipelago."
+                    );
 
                     ImGui::SameLine();
                     ImGui::Text("%d/%d recv/seed", APClient::recvIDs.size(), APClient::seedIDs.size());

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -17,33 +17,26 @@ namespace APGUI
     bool showWarning = true; // First run warning
 
     bool showImGuiDemo = false;
-    bool g_ImGuiInitialized = false;
     bool firstFrame = true;
-    bool prevUnfocused = false;
 
     ID3D11Device* g_Device = nullptr;
     ID3D11DeviceContext* g_Context = nullptr;
     HWND g_hWnd = nullptr;
     WNDPROC g_OriginalWndProc = nullptr;
 
-    void init(IDXGISwapChain* swapChain)
+    void init(IDXGISwapChain* swapChain, ID3D11Device* device, ID3D11DeviceContext* deviceContext)
     {
-        if (g_ImGuiInitialized)
-            return;
-
         ImGui_ImplWin32_EnableDpiAwareness();
         float main_scale = ImGui_ImplWin32_GetDpiScaleForMonitor(::MonitorFromPoint(POINT{ 0, 0 }, MONITOR_DEFAULTTOPRIMARY));
 
-        // Get device + context
-        swapChain->GetDevice(__uuidof(ID3D11Device), (void**)&g_Device);
-        g_Device->GetImmediateContext(&g_Context);
+        g_Device = device;
+        g_Context = deviceContext;
 
         // Get window handle
         DXGI_SWAP_CHAIN_DESC desc;
         swapChain->GetDesc(&desc);
         g_hWnd = desc.OutputWindow;
 
-        // Init ImGui
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
         ImGui::StyleColorsDark();
@@ -57,12 +50,10 @@ namespace APGUI
         ImGui_ImplWin32_Init(g_hWnd);
         ImGui_ImplDX11_Init(g_Device, g_Context);
 
-        g_ImGuiInitialized = true;
-
         APSettings::load();
     }
 
-    void onFrame()
+    void onFrame(IDXGISwapChain* swapChain)
     {
         ImGui_ImplDX11_NewFrame();
         ImGui_ImplWin32_NewFrame();

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -164,7 +164,7 @@ namespace APGUI
             ImGui::TextLinkOpenURL("Archipelago", "https://archipelago.gg");
             ImGui::SameLine(0.0f, 0.0f);
             ImGui::Text(", a multi-game randomizer.");
-            ImGui::Text("\nAdditional help can be found in its Discord linked on the website.");
+            ImGui::Text("\nFor more information, check the Help section under the Advanced tab.");
 
             ImGui::Separator();
             if (ImGui::Button("Okay"))

--- a/APGUI.cpp
+++ b/APGUI.cpp
@@ -60,7 +60,6 @@ namespace APGUI
         ImGui::NewFrame();
 
         // auto hide client when in game, not paused, not on results
-        auto PvPlayData = 0x1412C2330;
         if (auto_hide_client && *(bool*)PvPlayData && !*(bool*)(PvPlayData + 0x1) && !*(bool*)(PvPlayData + 0x2D17D)) {
             ImGui::GetIO().WantCaptureKeyboard = false;
             ImGui::GetIO().WantCaptureMouse = false;

--- a/APGUI.h
+++ b/APGUI.h
@@ -6,13 +6,11 @@
 
 namespace APGUI
 {
-    extern bool g_ImGuiInitialized;
-
     extern HWND g_hWnd;
     extern WNDPROC g_OriginalWndProc;
 
-    void init(IDXGISwapChain* swapChain);
-    void onFrame();
+    void init(IDXGISwapChain* swapChain, ID3D11Device* device, ID3D11DeviceContext* deviceContext);
+    void onFrame(IDXGISwapChain* swapChain);
     void warning();
     void ImGuiTab();
 

--- a/APHints.cpp
+++ b/APHints.cpp
@@ -96,7 +96,7 @@ namespace APHints
     {
         if (!hintsRequested) {
             auto name = "_read_hints_0_" + std::to_string(AP_GetPlayerID());
-            APClient::ServerDataRequest_Raw(name, hintsRequest, hintsRequested, hintsRaw_S);
+            //APClient::ServerDataRequest_Raw(name, hintsRequest, hintsRequested, hintsRaw_S);
             return;
         }
 

--- a/APHints.cpp
+++ b/APHints.cpp
@@ -198,7 +198,8 @@ namespace APHints
 
             if (ImGui::IsItemHovered()) {
                 ImGui::BeginTooltip();
-                ImGui::Text("Refresh checked status for non-song items.\nThis sends a !hint command in chat.");
+                ImGui::Text("Sends a !hint command in chat for better accuracy.\n"
+                            "New hints are not created and hint points are not spent.");
                 ImGui::EndTooltip();
             }
 

--- a/APHints.cpp
+++ b/APHints.cpp
@@ -171,123 +171,115 @@ namespace APHints
     {
         //if (!APClient::devMode) return;
 
-        if (ImGui::BeginTabItem("Hints")) {
-            if (!init) {
-                AP_Say("!hint");
-                init = true;
-            }
+        if (!init) {
+            AP_Say("!hint");
+            init = true;
+        }
 
-            /*if (hintsRequested)
-                refreshHints();*/
+        /*if (hintsRequested)
+            refreshHints();*/
 
-            ImGui::Checkbox("Hide checked", &hintHideChecked);
-            ImGui::SameLine();
-            HelpMarker("Non-song items may be out of date until manually refreshed.");
-            ImGui::SameLine();
+        ImGui::Checkbox("Hide checked", &hintHideChecked);
+        ImGui::SameLine();
+        HelpMarker("Non-song items may be out of date until manually refreshed.");
+        ImGui::SameLine();
 
-            float avail = ImGui::GetContentRegionAvail().x;
-            float buttonWidth = ImGui::CalcTextSize("Manual Refresh").x + ImGui::GetStyle().FramePadding.x * 2;
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - buttonWidth);
+        float avail = ImGui::GetContentRegionAvail().x;
+        float buttonWidth = ImGui::CalcTextSize("Manual Refresh").x + ImGui::GetStyle().FramePadding.x * 2;
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - buttonWidth);
 
-            //ImGui::BeginDisabled(true);
-            if (ImGui::Button("Manual Refresh")) {
-                drop();
-                AP_Say("!hint");
-            }
-            //ImGui::EndDisabled();
+        //ImGui::BeginDisabled(true);
+        if (ImGui::Button("Manual Refresh")) {
+            drop();
+            AP_Say("!hint");
+        }
+        //ImGui::EndDisabled();
 
-            if (ImGui::IsItemHovered()) {
-                ImGui::BeginTooltip();
-                ImGui::Text("Sends a !hint command in chat for better accuracy.\n"
-                            "New hints are not created and hint points are not spent.");
-                ImGui::EndTooltip();
-            }
+        if (ImGui::IsItemHovered()) {
+            ImGui::BeginTooltip();
+            ImGui::Text("Sends a !hint command in chat for better accuracy.\n"
+                        "New hints are not created and hint points are not spent.");
+            ImGui::EndTooltip();
+        }
 
-            ImGui::Checkbox("Show only my checks", &hintOwnLocationsOnly);
+        ImGui::Checkbox("Show only my checks", &hintOwnLocationsOnly);
 
-            ImGui::SameLine();
-            std::string hintLabel = std::to_string(Hints.size()) + " Hints";
-            avail = ImGui::GetContentRegionAvail().x;
-            buttonWidth = ImGui::CalcTextSize(hintLabel.c_str()).x;
-            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - buttonWidth);
-            ImGui::Text("%s", hintLabel.c_str());
+        ImGui::SameLine();
+        std::string hintLabel = std::to_string(Hints.size()) + " Hints";
+        avail = ImGui::GetContentRegionAvail().x;
+        buttonWidth = ImGui::CalcTextSize(hintLabel.c_str()).x;
+        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - buttonWidth);
+        ImGui::Text("%s", hintLabel.c_str());
 
-            if (ImGui::BeginChild("tableHintsContainer", ImVec2(0, 300))) {
-                if (ImGui::BeginTable("tableHints", 5,
-                    ImGuiTableFlags_BordersInner | ImGuiTableFlags_Hideable | ImGuiTableFlags_HighlightHoveredColumn |
-                    ImGuiTableFlags_Reorderable | ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg |
-                    ImGuiTableFlags_ScrollX | ImGuiTableFlags_SizingFixedFit
-                ))
-                {
-                    ImGui::TableSetupColumn(" ");
-                    ImGui::TableSetupColumn("Finder");
-                    ImGui::TableSetupColumn("Receiver");
-                    ImGui::TableSetupColumn("Item");
-                    ImGui::TableSetupColumn("Location");
-                    ImGui::TableHeadersRow();
+        if (ImGui::BeginTable("tableHints", 5,
+            ImGuiTableFlags_BordersInner | ImGuiTableFlags_Hideable | ImGuiTableFlags_HighlightHoveredColumn |
+            ImGuiTableFlags_Reorderable | ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg |
+            ImGuiTableFlags_ScrollX | ImGuiTableFlags_SizingFixedFit
+        ))
+        {
+            ImGui::TableSetupColumn(" ");
+            ImGui::TableSetupColumn("Finder");
+            ImGui::TableSetupColumn("Receiver");
+            ImGui::TableSetupColumn("Item");
+            ImGui::TableSetupColumn("Location");
+            ImGui::TableHeadersRow();
 
-                    int uid = 0;
-                    for (const AP_HintMessage& hint : Hints) {
-                        if (hintHideChecked && hint.checked)
-                            continue;
+            int uid = 0;
+            for (const AP_HintMessage& hint : Hints) {
+                if (hintHideChecked && hint.checked)
+                    continue;
 
-                        bool isMyCheck = isPlayer(hint.sendPlayer);
+                bool isMyCheck = isPlayer(hint.sendPlayer);
 
-                        if (hintOwnLocationsOnly && !isMyCheck)
-                            continue;
+                if (hintOwnLocationsOnly && !isMyCheck)
+                    continue;
 
-                        ImGui::TableNextRow();
+                ImGui::TableNextRow();
 
-                        uid += 1;
-                        ImGui::PushID(uid);
+                uid += 1;
+                ImGui::PushID(uid);
 
-                        ImGui::TableSetColumnIndex(0);
-                        ImGui::Text("%s", hint.checked ? "X" : " ");
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("%s", hint.checked ? "X" : " ");
 
-                        ImGui::TableSetColumnIndex(1);
-                        ImGui::Text("%s", hint.sendPlayer.c_str());
+                ImGui::TableSetColumnIndex(1);
+                ImGui::Text("%s", hint.sendPlayer.c_str());
 
-                        ImGui::TableSetColumnIndex(2);
-                        ImGui::Text("%s", hint.recvPlayer.c_str());
+                ImGui::TableSetColumnIndex(2);
+                ImGui::Text("%s", hint.recvPlayer.c_str());
 
-                        ImGui::TableSetColumnIndex(3);
-                        ImGui::Text("%s", hint.item.c_str());
+                ImGui::TableSetColumnIndex(3);
+                ImGui::Text("%s", hint.item.c_str());
 
-                        ImGui::TableSetColumnIndex(4);
+                ImGui::TableSetColumnIndex(4);
 
-                        // TODO: ID Remaps
-                        auto locID = location_name_to_id[hint.location.c_str()];
-                        auto itemName = item_ap_id_to_name[(locID / 10) * 10];
+                // TODO: ID Remaps
+                auto locID = location_name_to_id[hint.location.c_str()];
+                auto itemName = item_ap_id_to_name[(locID / 10) * 10];
 
-                        bool haveItem = isMyCheck && std::find(recvIDs.begin(), recvIDs.end(), locID / 10) != recvIDs.end();
+                bool haveItem = isMyCheck && std::find(recvIDs.begin(), recvIDs.end(), locID / 10) != recvIDs.end();
 
-                        if (haveItem)
-                            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));
+                if (haveItem)
+                    ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));
 
-                        ImGui::Text("%s", hint.location.c_str());
+                ImGui::Text("%s", hint.location.c_str());
 
-                        if (haveItem)
-                            ImGui::PopStyleColor();
+                if (haveItem)
+                    ImGui::PopStyleColor();
 
-                        if (isMyCheck && !haveItem) {
-                            if (ImGui::BeginPopupContextItem("##xx")) {
-                                if (ImGui::MenuItem("Hint this song##xx"))
-                                    AP_Say("!hint " + itemName);
+                if (isMyCheck && !haveItem) {
+                    if (ImGui::BeginPopupContextItem("##xx")) {
+                        if (ImGui::MenuItem("Hint this song##xx"))
+                            AP_Say("!hint " + itemName);
 
-                                ImGui::EndPopup();
-                            }
-                        }
-
-                        ImGui::PopID();
+                        ImGui::EndPopup();
                     }
-
-                    ImGui::EndTable();
                 }
 
-                ImGui::EndChild();
+                ImGui::PopID();
             }
 
-            ImGui::EndTabItem();
+            ImGui::EndTable();
         }
     }
 }

--- a/APHints.h
+++ b/APHints.h
@@ -26,7 +26,7 @@ namespace APHints
     void reset();
     void drop();
     bool isPlayer(const std::string &playerName);
-    void handleHintMessage(const AP_HintMessage&);
+    void handleHintMessage(const AP_HintMessage& recvHint);
     void updateSentLocations(const std::array<int64_t, 2> &locationIDs);
     void updateByItemName(const std::string &itemName);
 

--- a/APIDHandler.cpp
+++ b/APIDHandler.cpp
@@ -120,7 +120,7 @@ namespace APIDHandler
 		int64_t totalLocs = (seedIDs.size() - 1) * 2;
 
 		std::ostringstream trackerStream;
-		trackerStream << "Songs: " << recvIDs.size() << "/" << (seedIDs.size() - 1) << " | ";
+		trackerStream << "Songs: " << recvIDs.size() << "/" << seedIDs.size() << " | ";
 		trackerStream << "Locs: " << min(static_cast<int64_t>(CheckedLocations.size()), totalLocs) << "/" << totalLocs << " | ";
 		trackerStream << "Logic: " << availableLocs << " | ";
 		trackerStream << "Leeks: " << APClient::leekHave << "/" << APClient::leekNeed;

--- a/APIDHandler.cpp
+++ b/APIDHandler.cpp
@@ -117,115 +117,110 @@ namespace APIDHandler
 
 	void ImGuiTab()
 	{
-		if (ImGui::BeginTabItem("Tracker")) {
-			updateTrackerLine();
-			ImGui::Text(trackerLine.c_str());
+		updateTrackerLine();
 
-			if (ImGui::BeginTable("tableTrackerOptions", 2, ImGuiTableFlags_SizingStretchSame))
-			{
+		ImGui::PushTextWrapPos(0.0f);
+		ImGui::TextUnformatted(trackerLine.c_str());
+		ImGui::PopTextWrapPos();
+
+		if (ImGui::BeginTable("tableTrackerOptions", 2, ImGuiTableFlags_SizingStretchSame))
+		{
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+
+			if (ImGui::Checkbox("Freeplay", &freeplay))
+				APReload::run();
+			ImGui::SameLine();
+			HelpMarker("The entire song list will be available except for songs that have not been received yet.");
+
+			ImGui::TableSetColumnIndex(1);
+
+			if (ImGui::Checkbox("Hide checked", &hide_checked))
+				APReload::run();
+			ImGui::SameLine();
+			HelpMarker("When not in Freeplay, the song list will only show songs that have checks.");
+
+			ImGui::EndTable();
+		}
+
+		if (ImGui::BeginTable("tableTracker", 2,
+			ImGuiTableFlags_BordersInner | ImGuiTableFlags_Hideable | ImGuiTableFlags_HighlightHoveredColumn |
+			ImGuiTableFlags_Reorderable | ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg |
+			ImGuiTableFlags_ScrollX | ImGuiTableFlags_SizingFixedFit
+		))
+		{
+			ImGui::TableSetupColumn("Checks");
+			ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
+			ImGui::TableHeadersRow();
+
+			int _availableLocs = 0;
+			for (const auto& songID : recvIDs) {
+				auto loc1checked = std::find(CheckedLocations.begin(), CheckedLocations.end(), songID * 10) != CheckedLocations.end();
+				auto loc2checked = std::find(CheckedLocations.begin(), CheckedLocations.end(), (songID * 10) + 1) != CheckedLocations.end();
+
+				int available = (int)!loc1checked + (int)!loc2checked;
+
+				if (hide_checked && available == 0)
+					continue;
+
+				_availableLocs += available;
+
+				ImGui::PushID(static_cast<int>(songID));
+
 				ImGui::TableNextRow();
 				ImGui::TableSetColumnIndex(0);
 
-				if (ImGui::Checkbox("Freeplay", &freeplay))
-					APReload::run();
-				ImGui::SameLine();
-				HelpMarker("The entire song list will be available except for songs that have not been received yet.");
+				std::string label = (available > 0) ? std::to_string(available) : " ";
+				label = (songID == APClient::victoryID / 10) ? "GOAL" : label;
+
+				CenterText(label);
+				ImGui::Text("%s", label.c_str());
 
 				ImGui::TableSetColumnIndex(1);
+				std::string name = item_ap_id_to_name[songID * 10];
+				if (name.empty())
+					name = "ID " + std::to_string(songID) + " (not in datapackage)";
 
-				if (ImGui::Checkbox("Hide checked", &hide_checked))
-					APReload::run();
-				ImGui::SameLine();
-				HelpMarker("When not in Freeplay, the song list will only show songs that have checks.");
+				if (*(bool*)PvPlayData && songID == static_cast<int64_t>(*(int*)(PvPlayData + 0x10)))
+					name = "NP: " + name;
 
-				ImGui::EndTable();
-			}
+				bool isHinted = std::find(HintedIDs.begin(), HintedIDs.end(), songID) != HintedIDs.end();
 
-			if (ImGui::BeginChild("tableTrackerContainer", ImVec2(0, 300))) {
-				if (ImGui::BeginTable("tableTracker", 2,
-					ImGuiTableFlags_BordersInner | ImGuiTableFlags_Hideable | ImGuiTableFlags_HighlightHoveredColumn |
-					ImGuiTableFlags_Reorderable | ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg |
-					ImGuiTableFlags_ScrollX | ImGuiTableFlags_SizingFixedFit
-				))
+				if (isHinted)
+					ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));
+
+				ImGui::Text("%s", name.c_str());
+
+				if (isHinted)
+					ImGui::PopStyleColor();
+
+				if (APClient::devMode)
 				{
-					ImGui::TableSetupColumn("Checks");
-					ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthStretch);
-					ImGui::TableHeadersRow();
-
-					int _availableLocs = 0;
-					for (const auto& songID : recvIDs) {
-						auto loc1checked = std::find(CheckedLocations.begin(), CheckedLocations.end(), songID * 10) != CheckedLocations.end();
-						auto loc2checked = std::find(CheckedLocations.begin(), CheckedLocations.end(), (songID * 10) + 1) != CheckedLocations.end();
-
-						int available = (int)!loc1checked + (int)!loc2checked;
-
-						if (hide_checked && available == 0)
-							continue;
-
-						_availableLocs += available;
-
-						ImGui::PushID(static_cast<int>(songID));
-
-						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0);
-
-						std::string label = (available > 0) ? std::to_string(available) : " ";
-						label = (songID == APClient::victoryID / 10) ? "GOAL" : label;
-
-						CenterText(label);
-						ImGui::Text("%s", label.c_str());
-
-						ImGui::TableSetColumnIndex(1);
-						std::string name = item_ap_id_to_name[songID * 10];
-						if (name.empty())
-							name = "ID " + std::to_string(songID) + " (not in datapackage)";
-
-						if (*(bool*)PvPlayData && songID == static_cast<int64_t>(*(int*)(PvPlayData + 0x10)))
-							name = "NP: " + name;
-
-						bool isHinted = std::find(HintedIDs.begin(), HintedIDs.end(), songID) != HintedIDs.end();
-
-						if (isHinted)
-							ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));
-
-						ImGui::Text("%s", name.c_str());
-
-						if (isHinted)
-							ImGui::PopStyleColor();
-
-						if (APClient::devMode)
-						{
-							if (ImGui::BeginPopupContextItem("##xx"))
-							{
-								if (ImGui::MenuItem("Cheat##xx"))
-									APClient::LocationSend(songID);
-
-								ImGui::EndPopup();
-							}
-						}
-
-						ImGui::PopID();
-					}
-
-					if (_availableLocs == 0)
+					if (ImGui::BeginPopupContextItem("##xx"))
 					{
-						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0);
-						CenterText("BK");
-						ImGui::Text("BK");
-						ImGui::TableSetColumnIndex(1);
-						ImGui::Text("Waiting for songs...");
+						if (ImGui::MenuItem("Cheat##xx"))
+							APClient::LocationSend(songID);
+
+						ImGui::EndPopup();
 					}
-
-					availableLocs = _availableLocs;
-
-					ImGui::EndTable();
 				}
 
-				ImGui::EndChild();
+				ImGui::PopID();
 			}
 
-			ImGui::EndTabItem();
+			if (_availableLocs == 0)
+			{
+				ImGui::TableNextRow();
+				ImGui::TableSetColumnIndex(0);
+				CenterText("BK");
+				ImGui::Text("BK");
+				ImGui::TableSetColumnIndex(1);
+				ImGui::Text("Waiting for songs...");
+			}
+
+			availableLocs = _availableLocs;
+
+			ImGui::EndTable();
 		}
 	}
 }

--- a/APIDHandler.cpp
+++ b/APIDHandler.cpp
@@ -41,22 +41,6 @@ namespace APIDHandler
 		settings.insert("tracker", config);
 	}
 
-	bool checkNC()
-	{
-		if (!reload_needed)
-			return false;
-
-		HMODULE hModule = GetModuleHandle(L"NewClassics.dll");
-
-		if (hModule != NULL) {
-			APLogger::print("IDH: New Classics suspected, reload recommended\n");
-			return true;
-		}
-
-		reload_needed = false;
-		return false;
-	}
-
 	bool check(std::string& line)
 	{
 		if (reload_needed /*|| AP_GetConnectionStatus() != AP_ConnectionStatus::Authenticated*/ || missingIDs.size() == 0 || line.find("pv_") != 0)
@@ -76,12 +60,16 @@ namespace APIDHandler
 		int pvID = std::stoi(line.substr(start + 1, line.find_first_of(".") - start - 1));
 
 		// Always enabled to prevent softlocks or crashing.
-		if (144 == pvID || 700 == pvID || 701 == pvID)
+		if (144 == pvID || 700 == pvID)
 			return true;
 
 		auto begin = freeplay ? missingIDs.begin() : recvIDs.begin();
 		auto end = freeplay ? missingIDs.end() : recvIDs.end();
 		auto contains = std::find(begin, end, pvID) != end;
+
+		static HMODULE h701 = GetModuleHandle(L"pv701.dll");
+		if (701 == pvID && !contains && !h701)
+			return true;
 
 		if (!freeplay && contains && hide_checked)
 		{

--- a/APIDHandler.cpp
+++ b/APIDHandler.cpp
@@ -180,7 +180,6 @@ namespace APIDHandler
 						if (name.empty())
 							name = "ID " + std::to_string(songID) + " (not in datapackage)";
 
-						auto PvPlayData = 0x1412C2330;
 						if (*(bool*)PvPlayData && songID == static_cast<int64_t>(*(int*)(PvPlayData + 0x10)))
 							name = "NP: " + name;
 

--- a/APIDHandler.cpp
+++ b/APIDHandler.cpp
@@ -67,10 +67,6 @@ namespace APIDHandler
 		auto end = freeplay ? missingIDs.end() : recvIDs.end();
 		auto contains = std::find(begin, end, pvID) != end;
 
-		static HMODULE h701 = GetModuleHandle(L"pv701.dll");
-		if (701 == pvID && !contains && !h701)
-			return true;
-
 		if (!freeplay && contains && hide_checked)
 		{
 			for (const auto& songID : recvIDs) {

--- a/APIDHandler.cpp
+++ b/APIDHandler.cpp
@@ -9,7 +9,6 @@ namespace APIDHandler
 	bool exists = false;
 	bool freeplay = false;
 	bool hide_checked = true;
-	bool reload_needed = true;
 	bool reloading = false;
 
 	auto &CheckedLocations = APClient::CheckedLocations;
@@ -43,7 +42,7 @@ namespace APIDHandler
 
 	bool check(std::string& line)
 	{
-		if (reload_needed /*|| AP_GetConnectionStatus() != AP_ConnectionStatus::Authenticated*/ || missingIDs.size() == 0 || line.find("pv_") != 0)
+		if (missingIDs.size() == 0 || line.find("pv_") != 0 /*|| AP_GetConnectionStatus() != AP_ConnectionStatus::Authenticated*/)
 			return true;
 
 		size_t diff_pos = line.find(".difficulty.");

--- a/APIDHandler.cpp
+++ b/APIDHandler.cpp
@@ -19,6 +19,8 @@ namespace APIDHandler
 	auto &item_ap_id_to_name = APClient::item_ap_id_to_name;
 	int availableLocs = 0; // Calculated on reload
 
+	std::string trackerLine; // Holds the formatted Tracker line
+
 	auto &HintedIDs = APHints::HintedIDs;
 
 	void config(const toml::table& settings)
@@ -111,21 +113,30 @@ namespace APIDHandler
 		reloading = false;
 	}
 
+	void updateTrackerLine()
+	{
+		// TODO: Update from relevant send/recv callbacks
+
+		int64_t totalLocs = (seedIDs.size() - 1) * 2;
+
+		std::ostringstream trackerStream;
+		trackerStream << "Songs: " << recvIDs.size() << "/" << (seedIDs.size() - 1) << " | ";
+		trackerStream << "Locs: " << min(static_cast<int64_t>(CheckedLocations.size()), totalLocs) << "/" << totalLocs << " | ";
+		trackerStream << "Logic: " << availableLocs << " | ";
+		trackerStream << "Leeks: " << APClient::leekHave << "/" << APClient::leekNeed;
+
+		trackerLine = trackerStream.str();
+
+		// Dump for i.e. stream overlay
+		//std::ofstream tracker("stats.txt");
+		//tracker << trackerLine;
+	}
+
 	void ImGuiTab()
 	{
 		if (ImGui::BeginTabItem("Tracker")) {
-			ImGui::Text("Songs: %d/%d |", recvIDs.size(), seedIDs.size() - 1);
-
-			ImGui::SameLine();
-			int64_t totalLocs = (seedIDs.size() - 1) * 2;
-			// APCpp's check callback runs multiple times around goaling?
-			ImGui::Text("Locs: %d/%d |", min(static_cast<int64_t>(CheckedLocations.size()), totalLocs), totalLocs);
-
-			ImGui::SameLine();
-			ImGui::Text("In logic: %d |", availableLocs);
-
-			ImGui::SameLine();
-			ImGui::Text("Leeks: %d/%d", APClient::leekHave, APClient::leekNeed);
+			updateTrackerLine();
+			ImGui::Text(trackerLine.c_str());
 
 			if (ImGui::BeginTable("tableTrackerOptions", 2, ImGuiTableFlags_SizingStretchSame))
 			{

--- a/APIDHandler.h
+++ b/APIDHandler.h
@@ -12,7 +12,6 @@ namespace APIDHandler
 	void config(const toml::table& settings);
 	void save(toml::table& settings);
 
-	bool checkNC();
 	void lock();
 	void unlock();
 	bool check(std::string& line);

--- a/APIDHandler.h
+++ b/APIDHandler.h
@@ -4,11 +4,6 @@
 
 namespace APIDHandler
 {
-	// Mostly for New Classics, but improves stability overall.
-	// Load "everything" first then require a manual refresh.
-	// If true, do not act on toggleIDs.
-	extern bool reload_needed;
-
 	void config(const toml::table& settings);
 	void save(toml::table& settings);
 

--- a/APIDHandler.h
+++ b/APIDHandler.h
@@ -18,5 +18,6 @@ namespace APIDHandler
 	bool check(std::string& line);
 	void reset();
 
+	void updateTrackerLine();
 	void ImGuiTab();
 }

--- a/APLogger.cpp
+++ b/APLogger.cpp
@@ -31,7 +31,7 @@ namespace APLogger
     {
         char line[512];
 
-        time_t t = time(NULL);
+        time_t t = time(nullptr);
         struct tm tm;
         localtime_s(&tm, &t);
 

--- a/APLogger.cpp
+++ b/APLogger.cpp
@@ -63,7 +63,7 @@ namespace APLogger
         /*if (!APClient::devMode)
             return;*/
 
-        if (!ImGui::CollapsingHeader("Logging")) {
+        if (ImGui::CollapsingHeader("Logging")) {
             // TODO: Check write perms?
             ImGui::Checkbox("Log to file", &log_to_file);
             if (log_to_file) {

--- a/APReload.cpp
+++ b/APReload.cpp
@@ -19,6 +19,7 @@ namespace APReload
 
         reloadVal = section["key"].value_or<std::string>("F7");
         reloadVal = reloadVal.empty() ? "F7" : reloadVal;
+        std::transform(reloadVal.begin(), reloadVal.end(), reloadVal.begin(), [](unsigned char c) { return std::toupper(c); });
         reloadKeyCode = GetReloadKeyCode(reloadVal);
 
         APLogger::print("reload key: %s (0x%x)\n", reloadVal.c_str(), static_cast<int>(reloadKeyCode));
@@ -48,13 +49,13 @@ namespace APReload
 
     void scan()
     {
-        if (!hGameWindow || GetForegroundWindow() != hGameWindow)
+        if (!hGameWindow)
             return;
 
         static bool pressed = false;
 
         bool wasPressed = pressed;
-        pressed = (GetAsyncKeyState(reloadKeyCode) & 0x8000) != 0;
+        pressed = (GetKeyState(reloadKeyCode) & 0x8000) != 0;
 
         if (pressed && !wasPressed)
             run();

--- a/APReload.cpp
+++ b/APReload.cpp
@@ -60,20 +60,27 @@ namespace APReload
             run();
     }
 
-    void run()
+    bool canChangeState()
     {
-        int* state = (int*)0x14CC61078;
-        int* substate = (int*)0x14CC61094;
+        const int* state = (int*)0x14CC61078;
+        const int* substate = (int*)0x14CC61094;
 
         if (*state == 2 && *substate == 7 || *state == 0 /*|| *state == 3*/ || *state == 7) {
             // Init, test, and Cust. In game including FTUI, MV, practice, and results.
             // state 7: reproducible infinite load/crash when reloading on Cust screen with 4 or more charas.
             //          only covers main menu -> cust, not song list -> cust
             APLogger::print("Reloading blocked for state %i/%i\n", *state, *substate);
-            return;
+            return false;
         }
 
         APLogger::print("Reload < %i/%i\n", *state, *substate);
+        return true;
+    }
+
+    void run()
+    {
+        if (!canChangeState())
+            return;
 
         ChangeGameState(3);
 
@@ -84,7 +91,8 @@ namespace APReload
     void sleepStartup()
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(reloadDelay * 100));
-        ChangeGameSubState(0, 1);
+        if (canChangeState())
+            ChangeGameSubState(0, 1);
     }
 
     void ChangeGameState(int32_t state)

--- a/APSettings.cpp
+++ b/APSettings.cpp
@@ -8,9 +8,7 @@
 
 namespace APSettings
 {
-    namespace fs = std::filesystem;
-    auto LocalPath = fs::current_path();
-    const fs::path SettingsTOML = LocalPath / "settings.toml";
+    const std::filesystem::path SettingsTOML = BasePath / "settings.toml";
 
     void load()
     {

--- a/APTraps.cpp
+++ b/APTraps.cpp
@@ -241,70 +241,66 @@ namespace APTraps
 
 	void ImGuiTab()
 	{
-		if (ImGui::BeginTabItem("Traps")) {
-			char buf[32];
-			float songLength = *(float*)(PvPlayData + 0x2D338);
-			sprintf(buf, "%.03f / %.03f", getGameTime(), songLength);
-			ImGui::ProgressBar(getGameTime() / songLength, ImVec2(ImGui::GetContentRegionAvail().x, 0.0f), buf);
+		char buf[32];
+		float songLength = *(float*)(PvPlayData + 0x2D338);
+		sprintf(buf, "%.03f / %.03f", getGameTime(), songLength);
+		ImGui::ProgressBar(getGameTime() / songLength, ImVec2(ImGui::GetContentRegionAvail().x, 0.0f), buf);
 
-			ImGui::SliderFloat("Trap Duration", &trapDuration, 0.0f, 300.0f, "%.1f seconds");
+		ImGui::SliderFloat("Trap Duration", &trapDuration, 0.0f, 300.0f, "%.1f seconds");
+		ImGui::SameLine();
+		HelpMarker("Seconds until individual traps expire.\n0 to not expire for current attempt.");
+
+		ImGui::SliderFloat("Icon Reroll", &iconInterval, 0.0f, 60.0f, "%.1f seconds");
+		ImGui::SameLine();
+		HelpMarker("Seconds between icon rerolls while Icon trap is active.\n0 to only reroll once.");
+
+		ImGui::Checkbox("Allow Sudden and Hidden to overlap", &trapOverlap);
+		ImGui::Checkbox("Icon Trap: Random controller glyphs", &randomizeGlyphs);
+
+		if (devMode) {
+			ImGui::Separator();
+
+			if (ImGui::Button("Sudden"))
+				touchSudden();
 			ImGui::SameLine();
-			HelpMarker("Seconds until individual traps expire.\n0 to not expire for current attempt.");
-
-			ImGui::SliderFloat("Icon Reroll", &iconInterval, 0.0f, 60.0f, "%.1f seconds");
+			if (ImGui::Button("Hidden"))
+				touchHidden();
 			ImGui::SameLine();
-			HelpMarker("Seconds between icon rerolls while Icon trap is active.\n0 to only reroll once.");
+			if (ImGui::Button("Icon"))
+				touchIcon();
 
-			ImGui::Checkbox("Allow Sudden and Hidden to overlap", &trapOverlap);
-			ImGui::Checkbox("Icon Trap: Random controller glyphs", &randomizeGlyphs);
-
-			if (devMode) {
-				ImGui::Separator();
-
-				if (ImGui::Button("Sudden"))
-					touchSudden();
-				ImGui::SameLine();
-				if (ImGui::Button("Hidden"))
-					touchHidden();
-				ImGui::SameLine();
-				if (ImGui::Button("Icon"))
-					touchIcon();
-
-				if (ImGui::BeginTable("tableTraps", 2))
+			if (ImGui::BeginTable("tableTraps", 2))
+			{
+				if (isSudden)
 				{
-					if (isSudden)
-					{
-						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0);
-						ImGui::Text("Sudden");
-						ImGui::TableSetColumnIndex(1);
-						ImGui::Text("%.02f", trapDuration + timestampSudden - getGameTime());
-					}
-
-					if (isHidden)
-					{
-						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0);
-						ImGui::Text("Hidden");
-						ImGui::TableSetColumnIndex(1);
-						ImGui::Text("%.02f", trapDuration + timestampHidden - getGameTime());
-					}
-
-					if (savedIcon <= 12)
-					{
-						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0);
-						ImGui::Text("Icon");
-						ImGui::TableSetColumnIndex(1);
-						ImGui::Text("%.02f %i / %i", trapDuration + timestampIconStart - getGameTime(), getCurrentIcon(),
-									*reinterpret_cast<uint8_t*>(PvControllerGlyphBase));
-					}
-
-					ImGui::EndTable();
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+					ImGui::Text("Sudden");
+					ImGui::TableSetColumnIndex(1);
+					ImGui::Text("%.02f", trapDuration + timestampSudden - getGameTime());
 				}
-			}
 
-			ImGui::EndTabItem();
+				if (isHidden)
+				{
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+					ImGui::Text("Hidden");
+					ImGui::TableSetColumnIndex(1);
+					ImGui::Text("%.02f", trapDuration + timestampHidden - getGameTime());
+				}
+
+				if (savedIcon <= 12)
+				{
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+					ImGui::Text("Icon");
+					ImGui::TableSetColumnIndex(1);
+					ImGui::Text("%.02f %i / %i", trapDuration + timestampIconStart - getGameTime(), getCurrentIcon(),
+								*reinterpret_cast<uint8_t*>(PvControllerGlyphBase));
+				}
+
+				ImGui::EndTable();
+			}
 		}
 	}
 }

--- a/APTraps.cpp
+++ b/APTraps.cpp
@@ -37,18 +37,22 @@ namespace APTraps
 
 	void config(const toml::table& settings)
 	{
-		float config_duration = settings["duration"].value_or(trapDuration);
+		toml::table section;
+		if (settings.contains("traps") && settings["traps"].is_table())
+			section = *settings["traps"].as_table();
+
+		float config_duration = section["duration"].value_or(trapDuration);
 		trapDuration = std::clamp(config_duration, 0.0f, 300.0f);
 		APLogger::print("trap duration: %.02f (config: %.02f)\n", trapDuration, config_duration);
 
-		float config_iconinterval = settings["icon_reroll"].value_or(iconInterval);
+		float config_iconinterval = section["icon_interval"].value_or(iconInterval);
 		iconInterval = std::clamp(config_iconinterval, 0.0f, 60.0f);
-		APLogger::print("trap icon_reroll: %.02f (config: %.02f)\n", iconInterval, config_iconinterval);
+		APLogger::print("trap icon_interval: %.02f (config: %.02f)\n", iconInterval, config_iconinterval);
 
-		trapOverlap = settings["overlap"].value_or(false);
+		trapOverlap = section["overlap"].value_or(false);
 		APLogger::print("trap overlap: %d\n", trapOverlap);
 
-		randomizeGlyphs = settings["icon_glyphs"].value_or(false);
+		randomizeGlyphs = section["icon_glyphs"].value_or(false);
 		APLogger::print("trap icon_glyphs: %d\n", randomizeGlyphs);
 	}
 

--- a/APTraps.cpp
+++ b/APTraps.cpp
@@ -15,7 +15,6 @@ namespace APTraps
 
 	const uint64_t DivaGameControlConfig = 0x1401D6520;
 	const uint64_t PvControllerGlyphBase = 0x141133D30; // Copy of GCC Icon on load (0-12), original caller returns base glyph (0-2).
-	const uint64_t PvPlayData = 0x1412C2330;
 	//const uint64_t DivaGameModifier = PvPlayData + 0x2D120;
 	const uint64_t DivaGameTimer = PvPlayData + 0x2D33C;
 

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,10 +1,11 @@
 1. Archipelago Mod (MIT)
 2. Archipelago Logo (CC BY-NC 4.0)
 3. APCpp (LGPL 2.1)
-4. Dear ImGui (MIT)
-5. toml++ (MIT)
-6. JSON for Modern C++ (MIT)
-7. Detours (MIT)
+4. DivaModLoader (MIT)
+5. Dear ImGui (MIT)
+6. toml++ (MIT)
+7. JSON for Modern C++ (MIT)
+8. Detours (MIT)
 
 ==================================================
 
@@ -551,7 +552,33 @@ That's all there is to it!
 
 ==================================================
 
-4. Dear ImGui
+4. DivaModLoader
+
+MIT License
+
+Copyright (c) 2022 Skyth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==================================================
+
+5. Dear ImGui
 
 The MIT License (MIT)
 
@@ -577,7 +604,7 @@ SOFTWARE.
 
 ==================================================
 
-5. toml++
+6. toml++
 
 MIT License
 
@@ -598,7 +625,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 ==================================================
 
-6. JSON for Modern C++
+7. JSON for Modern C++
 
 MIT License 
 
@@ -624,7 +651,7 @@ SOFTWARE.
 
 ==================================================
 
-7. Detours
+8. Detours
 
 Copyright (c) Microsoft Corporation
 

--- a/Mod.cpp
+++ b/Mod.cpp
@@ -47,25 +47,26 @@ LRESULT CALLBACK HookedWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam
 
 HOOK(void, __fastcall, _PvResultsFinalize, 0x14024B800, char* PvPlayData, long long a2)
 {
-    auto &pvName = *reinterpret_cast<std::string*>(PvPlayData + 0x2CEF8);
-
     // This might be somewhere in PvPlayData without having to call out
     auto PvGameData = (char*)reinterpret_cast<uint64_t(__fastcall*)(void)>(0x14027DD90)();
     int diff[3];
     memcpy(diff, PvGameData, 3 * sizeof(int));
 
-    int &playerGrade = *reinterpret_cast<int*>(PvPlayData + 0x2D190);
-
     // A grade of 1 happens only at playerPercent < 40% (good luck surviving above Easy)
     // Instead of AP patching the comparison, recheck it here.
+    auto &pvID = *reinterpret_cast<int*>(PvPlayData + 0x10);
+    auto &pvName = *reinterpret_cast<std::string*>(PvPlayData + 0x2CEF8);
+    auto &playerGrade = *reinterpret_cast<int*>(PvPlayData + 0x2D190);
     auto &playerPercent = *reinterpret_cast<int*>(PvPlayData + 0x2D304);
     auto &clearPercent = *reinterpret_cast<int*>(PvPlayData + 0x2D308);
 
     if (playerGrade == 2 && playerPercent < clearPercent)
         playerGrade = 1; // "Cheap"
 
+    APLogger::print("Finished ID %i with grade %i\n", pvID, playerGrade);
+
     if (playerGrade >= APClient::clearGrade) {
-        APClient::LocationSend(*reinterpret_cast<int*>(PvPlayData + 0x10));
+        APClient::LocationSend(pvID);
     }
     else {
         //playerGrade = 0; // Potentially use the UI to communicate clearGrade?
@@ -73,6 +74,7 @@ HOOK(void, __fastcall, _PvResultsFinalize, 0x14024B800, char* PvPlayData, long l
         APDeathLink::deathLinked = true;
     }
 
+    // Run the original function, resets playerGrade to what it should be (if previously downgraded to Cheap)
     original_PvResultsFinalize(PvPlayData, a2);
 }
 

--- a/Mod.cpp
+++ b/Mod.cpp
@@ -182,6 +182,24 @@ HOOK(void, __fastcall, _load_null, 0x1405948E0, long long* a1, unsigned long lon
     original_load_null(a1, a2, a3, a4);
 }
 
+HOOK(void, __fastcall, _PvGameApplyDiff, 0x14027BB00, long long* data, int diff)
+{
+    // Dodging hooks from at least X SP and New Classics.
+    // Allow ID 700 (Ievan Polkka Tutorial) to be things other than Easy.
+    // TODO: Not this. Find out where the force to Easy happens.
+
+    const auto &pvID = *reinterpret_cast<int*>((char*)*data + 0x4);
+
+    if (pvID == 700) {
+        // Use last played base difficulty (ExEx might require shipping it in mod_pv_db, so skip for now)
+        auto PvGameData = (char*)reinterpret_cast<uint64_t(__fastcall*)(void)>(0x14027DD90)();
+        diff = *reinterpret_cast<int*>((char*)PvGameData + 0x4);
+        APLogger::print("Overriding ID 700 diff to %i\n", diff);
+    }
+
+    original_PvGameApplyDiff(data, diff);
+}
+
 extern "C"
 {
     void __declspec(dllexport) OnFrame(IDXGISwapChain* swapChain)
@@ -205,6 +223,7 @@ extern "C"
         INSTALL_HOOK(_PvResultsFinalize);
         INSTALL_HOOK(_PvLoop);
         INSTALL_HOOK(_PvCalculateGrade);
+        INSTALL_HOOK(_PvGameApplyDiff);
         INSTALL_HOOK(_ModifierSudden);
         INSTALL_HOOK(_ModifierHidden);
         INSTALL_HOOK(_SafetyDuration);

--- a/Mod.cpp
+++ b/Mod.cpp
@@ -56,25 +56,24 @@ HOOK(void, __fastcall, _PvResultsFinalize, 0x14024B800, char* PvPlayData, long l
     // Instead of AP patching the comparison, recheck it here.
     auto &pvID = *reinterpret_cast<int*>(PvPlayData + 0x10);
     auto &pvName = *reinterpret_cast<std::string*>(PvPlayData + 0x2CEF8);
-    auto &playerGrade = *reinterpret_cast<int*>(PvPlayData + 0x2D190);
+    // Pull playerGrade out for now instead of referencing. Potentially use the UI to communicate clearGrade?
+    int playerGrade = *reinterpret_cast<int*>(PvPlayData + 0x2D190);
     auto &playerPercent = *reinterpret_cast<int*>(PvPlayData + 0x2D304);
     auto &clearPercent = *reinterpret_cast<int*>(PvPlayData + 0x2D308);
 
     if (playerGrade == 2 && playerPercent < clearPercent)
         playerGrade = 1; // "Cheap"
 
-    APLogger::print("Finished ID %i with grade %i\n", pvID, playerGrade);
+    APLogger::print("Finished ID %i with grade %i >= %i\n", pvID, playerGrade, APClient::clearGrade);
 
     if (playerGrade >= APClient::clearGrade) {
         APClient::LocationSend(pvID);
     }
     else {
-        //playerGrade = 0; // Potentially use the UI to communicate clearGrade?
         APDeathLink::runAmnesty();
         APDeathLink::deathLinked = true;
     }
 
-    // Run the original function, resets playerGrade to what it should be (if previously downgraded to Cheap)
     original_PvResultsFinalize(PvPlayData, a2);
 }
 

--- a/Mod.cpp
+++ b/Mod.cpp
@@ -186,7 +186,7 @@ HOOK(void, __fastcall, _PvGameApplyDiff, 0x14027BB00, long long* data, int diff)
 {
     // Dodging hooks from at least X SP and New Classics.
     // Allow ID 700 (Ievan Polkka Tutorial) to be things other than Easy.
-    // TODO: Not this. Find out where the force to Easy happens.
+    // TODO: Not this. Find out where the force to Easy happens: 0x15E4BD270()
 
     const auto &pvID = *reinterpret_cast<int*>((char*)*data + 0x4);
 

--- a/Mod.cpp
+++ b/Mod.cpp
@@ -189,16 +189,18 @@ HOOK(void, __fastcall, _PvGameApplyDiff, 0x14027BB00, long long* data, int diff)
 
 extern "C"
 {
+    void __declspec(dllexport) D3DInit(IDXGISwapChain* swapChain, ID3D11Device* device, ID3D11DeviceContext* deviceContext)
+    {
+        APGUI::init(swapChain, device, deviceContext);
+        APGUI::g_OriginalWndProc = (WNDPROC)SetWindowLongPtr(APGUI::g_hWnd, GWLP_WNDPROC, (LONG_PTR)HookedWndProc);
+    }
+
     void __declspec(dllexport) OnFrame(IDXGISwapChain* swapChain)
     {
         APClient::CheckMessages();
+        APGUI::onFrame(swapChain);
 
-        APGUI::init(swapChain);
-        if (!APGUI::g_OriginalWndProc)
-            APGUI::g_OriginalWndProc = (WNDPROC)SetWindowLongPtr(APGUI::g_hWnd, GWLP_WNDPROC, (LONG_PTR)HookedWndProc);
-        APGUI::onFrame();
-
-        if (APGUI::g_ImGuiInitialized && !ImGui::GetIO().WantCaptureKeyboard)
+        if (!ImGui::GetIO().WantCaptureKeyboard)
             APReload::scan();
     }
 

--- a/Mod.cpp
+++ b/Mod.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "APClient.h"
 #include "APDeathLink.h"
 #include "APGUI.h"
@@ -5,12 +6,6 @@
 #include "APReload.h"
 #include "APTraps.h"
 #include "Diva.h"
-#include "pch.h"
-#include <Archipelago.h>
-#include <d3d11.h>
-#include <detours.h>
-#include <imgui_impl_dx11.h>
-#include <imgui_impl_win32.h>
 
 HOOK(bool, __fastcall, _InputEverythingElse, 0x1402AB070, long long a1, int btn)
 {

--- a/Mod.cpp
+++ b/Mod.cpp
@@ -135,20 +135,7 @@ HOOK(void, __fastcall, _ChangeGameSubState, 0x1527E49E0, int state, int substate
         skipped = false;
     }
     else if (state == 9 && substate == 47 || state == 6 && substate == 47) {
-        bool reload_was_needed = APIDHandler::reload_needed;
-        APIDHandler::reload_needed = false;
         APIDHandler::unlock();
-
-        if (reload_was_needed) {
-            if (APClient::recvIDs.size() > 0) {
-                APLogger::print("Forcing needed reload (have IDs)\n");
-                original_ChangeGameSubState(0, 1);
-                return;
-            }
-            else {
-                APLogger::print("Skipped needed reload (no IDs)\n");
-            }
-        }
 
        if (APReload::skipMainMenu && skipped == false) {
             APLogger::print("Skipping main menu (state: %d)\n", state);

--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,8 @@ Builds happen on commit and automatically weekly.
 ### Building (local)
 
 Archipelago Mod and APCpp build targets **need to be the same.** If you experience crashes, this is most likely why.
+You may need to create a `x64-Release` build config for APCpp if it does not exist and you want to build the AP Mod in Release.
+If there are linker errors fix them but the default paths should be fine.
 
 1. Clone recursively with `git clone --recurse-submodules`
    - [APCpp](https://github.com/N00byKing/APCpp) is pinned as a submodule, and has pinned submodules of its own.
@@ -13,13 +15,11 @@ Archipelago Mod and APCpp build targets **need to be the same.** If you experien
    - File > Open > Folder (Ctrl+Alt+Shift+O)
    - Open the APCpp folder
    - Right-click `CMakeLists.txt` in Solution Explorer > Build
-     - You may need to create a `x64-Release` Build target
-3. Copy/move/symlink `APCpp\out\build\x64-Debug\APCpp.dll` to the game's Archipelago Mod folder.
+3. Copy/move/symlink `APCpp\out\build\x64-CONFIG\APCpp.dll` to the game's Archipelago Mod folder.
+   - `CONFIG` being your build config.
    - This is dynamically linked when the mod loads. No need to edit `config.toml`.
 4. Build Archipelago Mod as normal.
 5. Copy/move/symlink the DLL to the game's Archipelago Mod folder.
-
-If there are linker errors fix them but the default paths should be fine.
 
 ### Building (GitHub action)
 

--- a/README.MD
+++ b/README.MD
@@ -13,6 +13,7 @@ Archipelago Mod and APCpp build targets **need to be the same.** If you experien
    - File > Open > Folder (Ctrl+Alt+Shift+O)
    - Open the APCpp folder
    - Right-click `CMakeLists.txt` in Solution Explorer > Build
+     - You may need to create a `x64-Release` Build target
 3. Copy/move/symlink `APCpp\out\build\x64-Debug\APCpp.dll` to the game's Archipelago Mod folder.
    - This is dynamically linked when the mod loads. No need to edit `config.toml`.
 4. Build Archipelago Mod as normal.

--- a/pch.h
+++ b/pch.h
@@ -23,6 +23,7 @@
 #include <thread>
 #include <toml++/toml.h>
 #include <imgui.h>
+#include <imgui_internal.h>
 #include <detours.h>
 #include <Archipelago.h>
 #include "APLogger.h"

--- a/pch.h
+++ b/pch.h
@@ -23,9 +23,15 @@
 #include <thread>
 #include <toml++/toml.h>
 #include <imgui.h>
+#include <detours.h>
 #include <Archipelago.h>
 #include "APLogger.h"
 #include "Helpers.h"
+
+const uint64_t PvPlayData = 0x1412C2330; // Struct eventually(TM)
+
+// ...\Hatsune Miku Project DIVA Mega Mix Plus\mods\ArchipelagoMod
+const std::filesystem::path BasePath = std::filesystem::current_path();
 
 // TODO: Relocate
 inline void HelpMarker(const char* desc)


### PR DESCRIPTION
- APGUI
  - If the GUI would be visible, also make the mouse cursor visible.
  - Rewrote the first run dialog to inform it's not intended to be used on its own and mention where to find more help
  - Added a Help section to the Advanced tab with relevant URLs.
  - Removed right-click safety confirmation for enabling dev mode.
  - Added separate default/in-game global alpha sliders for when the GUI is not hidden
  - Updated, switched to, and implemented imgui docking branch
    - Opt-in from `Advanced > Styling`
    - Allow windows to be resized instead of auto-fit
    - Tracker and Hints tab now use all vertical space
- APClient
  - Updated APCpp
  - Added a tooltip of the reload key to the Client tab's Reload button 
  - Now uses APCpp's raw slot data callbacks instead of pulling slot data (again) directly
  - `::reset` now clears `missingIDs`, restoring the whole song list on (intentional) disconnect
  - `::LocationSend` updated to not send IDs unless already received which should be 1:1 with the Tracker tab.
    - This is to prevent misfires of the pending AP and Tutorial songs being available in the song pool.
  - Only process trap items that are newly received
  - Small right-click menu improvements
  - Added a help tooltip for the Server text input
  - Added these log lines:
    - _PvResultsFinalize hook: `Finished ID # with grade # >= #`
    - `APClient::LocationSend`
      - `Client: Skip location send for ID # (not received)`
      - `Client: Sending goal completion from ID #`
      - `Client: Sending locations for ID #`
- APIDHandler
  - ID 701 is no longer guaranteed to be visible like 144 and 700
  - Refactored Tracker line generation 
    - Potential to write it out to use as a streaming element
- APTraps
  - Fixed trap settings not loading properly
- APReload
  - Checks state being changed from again when thread completes
  - Clean up key press detection
  - Convert the config's key value to uppercase for the code lookup
- APDeathLink
  - Respects toggle since bounce tag is permanently active
- Disable caching of APCpp in GH action

Known issues: (preexisting or otherwise)
 - Prog HP does not reset properly between slot changes
 - HP may stop updating entirely (possibly prog HP related)
 - Logging to file?
